### PR TITLE
Replaces static IDs for read/write to dynamic computed

### DIFF
--- a/src/communication.h
+++ b/src/communication.h
@@ -15,7 +15,7 @@ struct CanMember {
     CANID CanId;
     std::string name;
     bool operator<(const CanMember& other) const { return CanId < other.CanId; }
-    std::uint16_t getWriteId() const { return (getWriteId1() | (getWriteId2() << 8U)); }
+    std::uint16_t getWriteId() const { return (getWriteId2() | (getWriteId1() << 8U)); }
     std::uint16_t getReadId() const { return (getReadId2() | (getReadId1() << 8U)); }
     std::uint8_t getReadId1() const { return (CanId >> 3) + 1;} // divide by 8 and + 1 for reading a register
     std::uint8_t getReadId2() const { return (CanId & 0xF);} // + last hex digit of Can ID

--- a/yaml/wp_base.yaml
+++ b/yaml/wp_base.yaml
@@ -496,7 +496,7 @@ canbus:
     id: my_mcp2515
     spi_id: McpSpi
     cs_pin: $cs_pin
-    can_id: 680
+    can_id: 0x680
     use_extended_id: false
     bit_rate: 20kbps
     on_frame:


### PR DESCRIPTION
Setting Read/Write IDs is potentially error prone. Instead I suggest to apply the sheme as described here: http://juerg5524.ch/data/Telegramm-Aufbau.txt to generate the IDs based on the CAN ID.