### PR TITLE
Fix LUEFT_XXX_STUFE units and use as number

### DIFF
--- a/yaml/thz5_5_eco.yaml
+++ b/yaml/thz5_5_eco.yaml
@@ -8,11 +8,11 @@ packages:
   
   LUEFT_STUFE_BEREITSCHAFT:       !include { file: wp_ventilation.yaml, vars: { property: "LUEFT_STUFE_BEREITSCHAFT" }}
   LUEFT_STUFE_HAND:               !include { file: wp_ventilation.yaml, vars: { property: "LUEFT_STUFE_HAND" }}
-  LUEFT_ZULUFT_STUFE1:            !include { file: wp_generic.yaml, vars: { property: "LUEFT_ZULUFT_STUFE1",icon: "mdi:pump", unit: "l/min", interval: $interval_medium  }}
-  LUEFT_ZULUFT_STUFE2:            !include { file: wp_generic.yaml, vars: { property: "LUEFT_ZULUFT_STUFE2",icon: "mdi:pump", unit: "l/min", interval: $interval_medium  }}
-  LUEFT_ZULUFT_STUFE3:            !include { file: wp_generic.yaml, vars: { property: "LUEFT_ZULUFT_STUFE3",icon: "mdi:pump", unit: "l/min", interval: $interval_medium  }}
-  LUEFT_ABLUFT_STUFE1:            !include { file: wp_generic.yaml, vars: { property: "LUEFT_ABLUFT_STUFE1",icon: "mdi:pump", unit: "l/min", interval: $interval_medium  }}
-  LUEFT_ABLUFT_STUFE2:            !include { file: wp_generic.yaml, vars: { property: "LUEFT_ABLUFT_STUFE2",icon: "mdi:pump", unit: "l/min", interval: $interval_medium  }}
-  LUEFT_ABLUFT_STUFE3:            !include { file: wp_generic.yaml, vars: { property: "LUEFT_ABLUFT_STUFE3",icon: "mdi:pump", unit: "l/min", interval: $interval_medium  }}
+  LUEFT_ZULUFT_STUFE1:            !include { file: wp_number.yaml, vars: { property: "LUEFT_ZULUFT_STUFE1",icon: "mdi:pump", unit: "m³/h"  }}
+  LUEFT_ZULUFT_STUFE2:            !include { file: wp_number.yaml, vars: { property: "LUEFT_ZULUFT_STUFE2",icon: "mdi:pump", unit: "m³/h"  }}
+  LUEFT_ZULUFT_STUFE3:            !include { file: wp_number.yaml, vars: { property: "LUEFT_ZULUFT_STUFE3",icon: "mdi:pump", unit: "m³/h"  }}
+  LUEFT_ABLUFT_STUFE1:            !include { file: wp_number.yaml, vars: { property: "LUEFT_ABLUFT_STUFE1",icon: "mdi:pump", unit: "m³/h"  }}
+  LUEFT_ABLUFT_STUFE2:            !include { file: wp_number.yaml, vars: { property: "LUEFT_ABLUFT_STUFE2",icon: "mdi:pump", unit: "m³/h"  }}
+  LUEFT_ABLUFT_STUFE3:            !include { file: wp_number.yaml, vars: { property: "LUEFT_ABLUFT_STUFE3",icon: "mdi:pump", unit: "m³/h"  }}
   LAUFZEIT_FILTER_TAGE:           !include { file: wp_generic.yaml, vars: { property: "LAUFZEIT_FILTER_TAGE",icon: "mdi:air-filter", unit: "d", interval: $interval_once_in_a_while  }}
 


### PR DESCRIPTION
Requesting these values makes little to no sense, they are usually set once and then selected via LUEFT_STUFE_XXX. It might make sense to be able to set the values via HA, but this requires number entities.

@croessi please reconsider, if those values are really of any use ... I want to avoid having 500 entities that no one uses in the end