### PR TITLE
Binary and datetime

### DIFF
--- a/yaml/wp_base.yaml
+++ b/yaml/wp_base.yaml
@@ -156,12 +156,6 @@ packages:
   LUEFT_STUFE_PARTY:              !include { file: wp_ventilation.yaml, vars: { property: "LUEFT_STUFE_PARTY" }}
 
   FEHLERMELDUNG:                  !include { file: wp_generic.yaml, vars: { property: "FEHLERMELDUNG"            , icon: "mdi:alert-circle" }}
-  JAHR:                           !include { file: wp_generic.yaml, vars: { property: "JAHR"                     , icon: "mdi:calendar" }}
-  MONAT:                          !include { file: wp_generic.yaml, vars: { property: "MONAT"                    , icon: "mdi:calendar" }}
-  WOCHENTAG:                      !include { file: wp_generic.yaml, vars: { property: "WOCHENTAG"                , icon: "mdi:calendar-today" }}
-  TAG:                            !include { file: wp_generic.yaml, vars: { property: "TAG"                      , icon: "mdi:calendar-today" }}
-  STUNDE:                         !include { file: wp_generic.yaml, vars: { property: "STUNDE"                   , icon: "mdi:calendar-clock" }}
-  MINUTE:                         !include { file: wp_generic.yaml, vars: { property: "MINUTE"                   , icon: "mdi:calendar-clock" }}
   ANZEIGE_NIEDERDRUCK:            !include { file: wp_generic.yaml, vars: { property: "ANZEIGE_NIEDERDRUCK"      , accuracy_decimals: "2" }}
   PUMPENZYKLEN_MIN_AUSSENT:       !include { file: wp_generic.yaml, vars: { property: "PUMPENZYKLEN_MIN_AUSSENT" }}
   FEUCHTE:                        !include { file: wp_generic.yaml, vars: { property: "FEUCHTE"                  , interval: $interval_very_slow, unit: "%", icon: "mdi:water-percent", target: "HK1", accuracy_decimals: "1" }}
@@ -193,6 +187,9 @@ packages:
   WAERMEERTRAG_2WE_HEIZ_TAG_SUMME_KWH: !include { file: wp_daily_energy_combined.yaml, vars: { sensor_name: "WAERMEERTRAG_2WE_HEIZ_TAG_SUMME_KWH", property_wh: "WAERMEERTRAG_2WE_HEIZ_TAG_WH"   , property_kwh: "WAERMEERTRAG_2WE_HEIZ_TAG_KWH"    }}
   WAERMEERTRAG_WW_TAG_SUMME_KWH:       !include { file: wp_daily_energy_combined.yaml, vars: { sensor_name: "WAERMEERTRAG_WW_TAG_SUMME_KWH"      , property_wh: "WAERMEERTRAG_WW_TAG_WH"         , property_kwh: "WAERMEERTRAG_WW_TAG_KWH"          }}
   WAERMEERTRAG_HEIZ_TAG_SUMME_KWH:     !include { file: wp_daily_energy_combined.yaml, vars: { sensor_name: "WAERMEERTRAG_HEIZ_TAG_SUMME_KWH"    , property_wh: "WAERMEERTRAG_HEIZ_TAG_WH"       , property_kwh: "WAERMEERTRAG_HEIZ_TAG_KWH"        }}
+
+  HEATPUMP_DATETIME: !include { file: wp_datetime.yaml }
+
 #########################################
 #                                       #
 #   Sensors                             #

--- a/yaml/wp_base.yaml
+++ b/yaml/wp_base.yaml
@@ -72,80 +72,6 @@ switch:
 
 #########################################
 #                                       #
-#   Binary Sensors                      #
-#                                       #
-#########################################
-binary_sensor:
-  - platform: template
-    name: "SCHALTPROGRAMM_AKTIV"
-    id: SCHALTPROGRAMM_AKTIV
-
-  - platform: template
-    name: "VERDICHTER"
-    id: VERDICHTER
-
-  - platform: template
-    name: "HEIZEN"
-    id: HEIZEN
-
-  - platform: template
-    name: "KUEHLEN"
-    id: KUEHLEN
-
-  - platform: template
-    name: "WARMWASSERBEREITUNG"
-    id: WARMWASSERBEREITUNG
-
-  - platform: template
-    name: "ELEKTRISCHE_NACHERWAERMUNG"
-    id: ELEKTRISCHE_NACHERWAERMUNG
-
-  - platform: template
-    name: "SERVICE"
-    id: SERVICE
-
-  - platform: template
-    name: "EVU_SPERRE"
-    id: EVU_SPERRE
-
-  - platform: template
-    name: "FILTERWECHSEL_BEIDE"
-    id: FILTERWECHSEL_BEIDE
-
-  - platform: template
-    name: "LUEFTUNG"
-    id: LUEFTUNG
-
-  - platform: template
-    name: "HEIZKREISPUMPE"
-    id: HEIZKREISPUMPE
-
-  - platform: template
-    name: "ABTAUEN_VERDAMPFER"
-    id: ABTAUEN_VERDAMPFER
-
-  - platform: template
-    name: "FILTERWECHSEL_ABLUFT"
-    id: FILTERWECHSEL_ABLUFT
-
-  - platform: template
-    name: "FILTERWECHSEL_ZULUFT"
-    id: FILTERWECHSEL_ZULUFT
-
-  - platform: template
-    name: "AUFHEIZPROGRAMM_AKTIV"
-    id: AUFHEIZPROGRAMM_AKTIV
-
-  - platform: template
-    name: "SOMMERBETRIEB_AKTIV"
-    id: SOMMERBETRIEB_AKTIV
-
-  - platform: template
-    name: "OFEN_KAMIN_AKTIV"
-    id: OFEN_KAMIN_AKTIV
-
-#########################################
-#                                       #
 #   Intervals                           #
 #                                       #
 #########################################
@@ -184,6 +110,24 @@ interval:
 #                                       #
 #########################################
 packages:
+  SCHALTPROGRAMM_AKTIV:       !include { file: wp_binary.yaml, vars: { name: "SCHALTPROGRAMM_AKTIV" }}
+  VERDICHTER:                 !include { file: wp_binary.yaml, vars: { name: "VERDICHTER" }}
+  WARMWASSERBEREITUNG:        !include { file: wp_binary.yaml, vars: { name: "WARMWASSERBEREITUNG" }}
+  ELEKTRISCHE_NACHERWAERMUNG: !include { file: wp_binary.yaml, vars: { name: "ELEKTRISCHE_NACHERWAERMUNG" }}
+  SERVICE:                    !include { file: wp_binary.yaml, vars: { name: "SERVICE" }}
+  HEIZEN:                     !include { file: wp_binary.yaml, vars: { name: "HEIZEN" }}
+  KUEHLEN:                    !include { file: wp_binary.yaml, vars: { name: "KUEHLEN" }}
+  LUEFTUNG:                   !include { file: wp_binary.yaml, vars: { name: "LUEFTUNG" }}
+  EVU_SPERRE:                 !include { file: wp_binary.yaml, vars: { name: "EVU_SPERRE" }}
+  FILTERWECHSEL_BEIDE:        !include { file: wp_binary.yaml, vars: { name: "FILTERWECHSEL_BEIDE" }}
+  HEIZKREISPUMPE:             !include { file: wp_binary.yaml, vars: { name: "HEIZKREISPUMPE" }}
+  ABTAUEN_VERDAMPFER:         !include { file: wp_binary.yaml, vars: { name: "ABTAUEN_VERDAMPFER" }}
+  FILTERWECHSEL_ABLUFT:       !include { file: wp_binary.yaml, vars: { name: "FILTERWECHSEL_ABLUFT" }}
+  FILTERWECHSEL_ZULUFT:       !include { file: wp_binary.yaml, vars: { name: "FILTERWECHSEL_ZULUFT" }}
+  AUFHEIZPROGRAMM_AKTIV:      !include { file: wp_binary.yaml, vars: { name: "AUFHEIZPROGRAMM_AKTIV" }}
+  SOMMERBETRIEB_AKTIV:        !include { file: wp_binary.yaml, vars: { name: "SOMMERBETRIEB_AKTIV" }}
+  OFEN_KAMIN_AKTIV:           !include { file: wp_binary.yaml, vars: { name: "OFEN_KAMIN_AKTIV" }}
+
   VERDICHTER_STARTS:               !include { file: wp_generic_combined.yaml, vars: { sensor_name: "VERDICHTER_STARTS"                  , scaled_property: "VERDICHTER_STARTS_K"          , property: "VERDICHTER_STARTS"            , unit: ""   , accuracy_decimals: "0", scaler: "1000", icon: "mdi:counter" }}
   WAERMEERTRAG_RUECKGE_SUMME_MWH:  !include { file: wp_generic_combined.yaml, vars: { sensor_name: "WAERMEERTRAG_RUECKGE_SUMME_MWH"     , scaled_property: "WAERMEERTRAG_RUECKGE_SUM_KWH" , property: "WAERMEERTRAG_RUECKGE_SUM_MWH" , unit: "MWh", accuracy_decimals: "3", icon: "mdi:fire"  }}
   WAERMEERTRAG_2WE_WW_SUMME_MWH:   !include { file: wp_generic_combined.yaml, vars: { sensor_name: "WAERMEERTRAG_2WE_WW_SUMME_MWH"      , scaled_property: "WAERMEERTRAG_2WE_WW_SUM_KWH"  , property: "WAERMEERTRAG_2WE_WW_SUM_MWH"  , unit: "MWh", accuracy_decimals: "3", icon: "mdi:fire"  }}

--- a/yaml/wp_binary.yaml
+++ b/yaml/wp_binary.yaml
@@ -1,0 +1,4 @@
+binary_sensor:
+  - platform: template
+    name: ${name}
+    id: ${name}

--- a/yaml/wp_datetime.yaml
+++ b/yaml/wp_datetime.yaml
@@ -1,0 +1,56 @@
+esphome:
+  on_boot:
+    priority: -100
+    then:
+      - lambda: |-
+            id(HEATPUMP_DATETIME).state = "2024-01-01 12:34";
+            auto updateTime = [](auto&& updateTimeFragment){
+                ESPTime timeToSet{};
+                // get the datetime as string and parse to ESPTime object
+                if(const auto success = ESPTime::strptime(id(HEATPUMP_DATETIME).state, timeToSet); !success) {
+                  ESP_LOGE("DATETIME", "Error parsing datetime string %s", id(HEATPUMP_DATETIME).state.c_str());
+                  return;
+                }
+                // update the part that belongs to this sensor
+                updateTimeFragment(timeToSet);
+                // convert the time back to string and directly save it to the state of the datetime sensor
+                timeToSet.strftime(id(HEATPUMP_DATETIME).state.data(), 20, "%Y-%m-%d %H:%M");
+                // publish the value
+                id(HEATPUMP_DATETIME).publish_state(id(HEATPUMP_DATETIME).state);
+            };
+            CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kJAHR),[updateTime](const SimpleVariant& value){
+              updateTime([&value](ESPTime& timeToSet){
+                timeToSet.year = 2000U + static_cast<std::uint16_t>(value);
+              });
+            });
+            CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kMONAT),[updateTime](const SimpleVariant& value){
+              updateTime([&value](ESPTime& timeToSet){
+                timeToSet.month = static_cast<std::uint16_t>(value);
+              });
+            });
+            CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kTAG),[updateTime](const SimpleVariant& value){
+              updateTime([&value](ESPTime& timeToSet){
+                timeToSet.day_of_month = static_cast<std::uint16_t>(value);
+              });
+            });
+            CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kSTUNDE),[updateTime](const SimpleVariant& value){
+              updateTime([&value](ESPTime& timeToSet){
+                timeToSet.hour = static_cast<std::uint16_t>(value);
+              });
+            });
+            CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kMINUTE),[updateTime](const SimpleVariant& value){
+              updateTime([&value](ESPTime& timeToSet){
+                timeToSet.minute = static_cast<std::uint16_t>(value);
+              });
+            });
+            queueRequest(Kessel, Property::kJAHR);
+            queueRequest(Kessel, Property::kMONAT);
+            queueRequest(Kessel, Property::kTAG);
+            queueRequest(Kessel, Property::kSTUNDE);
+            queueRequest(Kessel, Property::kMINUTE);
+
+text_sensor:
+  - platform: template
+    name: "HEATPUMP_DATETIME"
+    id: HEATPUMP_DATETIME
+    update_interval: never


### PR DESCRIPTION
Further improve readability of wp_base.yaml by moving binary sensors out
Also year, month, day, hour and minute are published together as datetime now

closes #41 