### PR TITLE
Rename CAN to wp_can and move pins + platform out

### DIFF
--- a/esp32-poe-technik.yaml
+++ b/esp32-poe-technik.yaml
@@ -48,6 +48,12 @@ substitutions:
   entity_room_temperature: "sensor.durchschnittstemperatur_haus_ohne_keller"
   entity_humidity: "sensor.durchschnitt_luftfeuchtigkeit_haus"
 
+canbus:
+  - id: !extend wp_can
+    platform: mcp2515
+    spi_id: McpSpi
+    cs_pin: GPIO15
+
 button:
   - platform: restart
     name: "Restart ESP32-PoE Technik"

--- a/src/communication.h
+++ b/src/communication.h
@@ -95,7 +95,7 @@ void requestData(const CanMember& member, const Property& property) {
 
     data.insert(data.end(), {IdByte1, IdByte2, 0xfa, IndexByte1, IndexByte2, 0x00, 0x00});
 
-    id(my_mcp2515).send_data(ESPClient.CanId, use_extended_id, data);
+    id(wp_can).send_data(ESPClient.CanId, use_extended_id, data);
 }
 
 /**
@@ -116,7 +116,7 @@ void sendData(const CanMember& member, const Property property, const std::uint1
 
     data.insert(data.end(), {IdByte1, IdByte2, 0xfa, IndexByte1, IndexByte2, ValueByte1, ValueByte2});
 
-    id(my_mcp2515).send_data(ESPClient.CanId, use_extended_id, data);
+    id(wp_can).send_data(ESPClient.CanId, use_extended_id, data);
 }
 
 #endif

--- a/yaml/wp_base.yaml
+++ b/yaml/wp_base.yaml
@@ -320,10 +320,7 @@ climate:
 #                                       #
 #########################################
 canbus:
-  - platform: mcp2515
-    id: my_mcp2515
-    spi_id: McpSpi
-    cs_pin: $cs_pin
+  - id: wp_can
     can_id: 680
     use_extended_id: false
     bit_rate: 20kbps


### PR DESCRIPTION
This allows others that don't use mcp2515 to define their can config in their main yaml.