### PR TITLE
Allow multiple callbacks per target&property pair

### DIFF
--- a/yaml/wp_base.yaml
+++ b/yaml/wp_base.yaml
@@ -12,10 +12,10 @@ esphome:
           });
           queueRequest(Kessel, Property::kPASSIVKUEHLUNG);
 
-          CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kZULUFT_SOLL),[](const SimpleVariant& value){
+          CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kZULUFT_IST),[](const SimpleVariant& value){
             // workaround for broken ninth bit of BETRIEBSSTATUS
-            const auto zuluftSoll = static_cast<std::uint16_t>(value);
-            id(LUEFTUNG).publish_state(zuluftSoll > 0U);
+            const auto zuluftIst = static_cast<std::uint16_t>(value);
+            id(LUEFTUNG).publish_state(zuluftIst > 0U);
           });
 
 #########################################


### PR DESCRIPTION
Having this might be useful in the future and also fixes the fix for the broken ventilation -_-

Callbacks are merged via intermediate lambda to keep the existing interface.

POC: https://godbolt.org/z/c6adPe46G