### PR TITLE
Allow daily energy combined sensor to be reset at midnight

### DIFF
--- a/src/communication.h
+++ b/src/communication.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "esphome.h"
 #include "mapper.h"
 #include "property.h"
 #include "type.h"

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -87,3 +87,7 @@ SimpleVariant GetValueByType(const std::uint16_t value, const Type type) {
             return value;
     }
 }
+
+std::uint16_t toggleEndianness(const std::uint16_t value) {
+    return (((value & 0xFF00) >> 8U) | ((value & 0x00FF) << 8U));
+}

--- a/src/type.h
+++ b/src/type.h
@@ -37,4 +37,12 @@ T getParamType(void (C::*)(T));
  */
 SimpleVariant GetValueByType(const std::uint16_t value, const Type type);
 
+/**
+ * @brief Toggles endianness of an unsigned 16-bit integer.
+ *        Needed whenever payload of type et_little_endian is sent/received
+ *        little endian (CAN bus) -> big endian    (ESPHome)
+ *        big endian    (ESPHome) -> little endian (CAN bus)
+ */
+uint16_t toggleEndianness(const uint16_t value);
+
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,28 @@
+#if !defined(UTIL_H)
+#define UTIL_H
+
+#include "communication.h"
+#include "esp_log.h"
+#include "esphome.h"
+#include "property.h"
+#include "type.h"
+
+/**
+ * @brief Synchronizes the time of the heat pump to the one received via sntp.
+ */
+void syncTime() {
+    const auto time = id(sntp_time).now();
+    if (!time.is_valid()) {
+        ESP_LOGE("TIMESYNC", "Cannot sync time. SNTP time is invalid.");
+        return;
+    }
+    ESP_LOGI("TIMESYNC", "Synchronizing heat pump time to %d.%d.%d %d:%d", time.day_of_month, time.month, time.year,
+             time.hour, time.minute);
+    sendData(Kessel, Property::kJAHR, toggleEndianness(time.year - 2000U));
+    sendData(Kessel, Property::kMONAT, toggleEndianness(time.month));
+    sendData(Kessel, Property::kTAG, toggleEndianness(time.day_of_month));
+    sendData(Kessel, Property::kSTUNDE, toggleEndianness(time.hour));
+    sendData(Kessel, Property::kMINUTE, toggleEndianness(time.minute));
+}
+
+#endif

--- a/yaml/common.yaml
+++ b/yaml/common.yaml
@@ -9,6 +9,7 @@ esphome:
     - OneESP32ToRuleThemAll/src/simple_variant.h
     - OneESP32ToRuleThemAll/src/type.h
     - OneESP32ToRuleThemAll/src/type.cpp
+    - OneESP32ToRuleThemAll/src/util.h
   platformio_options:
     build_flags:
       - "-DESPCLIENT_ID=$espclient_can_id"
@@ -42,6 +43,35 @@ globals:
   - id: gCOP_HEIZ_TAG
     type: float
     initial_value: "0.0"
+
+#########################################
+#                                       #
+#   Time Synchronization                #
+#                                       #
+#########################################
+time:
+  - platform: sntp
+    id: sntp_time
+    on_time:
+      - seconds: 0
+        minutes: 0
+        hours: 3 # sync at 3 am should be ok even with switch from/to daylight saving time
+        then:
+          - lambda: |-
+              syncTime();
+
+#########################################
+#                                       #
+#   Buttons                             #
+#                                       #
+#########################################
+button:
+  - platform: template
+    name: Synchronize Time
+    on_press:
+      then:
+        - lambda: |-
+            syncTime();
 
 #########################################
 #                                       #

--- a/yaml/wp_daily_energy_combined.yaml
+++ b/yaml/wp_daily_energy_combined.yaml
@@ -19,8 +19,14 @@ sensor:
     update_interval: never
     filters:
       - multiply: 0.001
-      - lambda: return x - id(gOFFSET_${property_wh});
-      
+      - lambda: |-
+          const auto newValue{x - id(gOFFSET_${property_wh})};
+          // readings shall never be negative
+          if(newValue > 0.0) {
+            return newValue;
+          }
+          return 0.0;
+
   - platform: template
     name: ${sensor_name}
     id: ${sensor_name}
@@ -50,17 +56,9 @@ esphome:
 time:
   - platform: sntp
     on_time:
-      # Every hour, every 5 minutes except midnight.
+      # Every hour, every 5 minutes starting at 4 minutes.
       - seconds: 0
-        minutes: 5/5
-        hours: 0-23
-        then:
-          - lambda: |-
-              queueRequest(${target}, Property::k${property_wh});
-              queueRequest(${target}, Property::k${property_kwh});
-      - seconds: 0
-        minutes: 0
-        hours: 1-23
+        minutes: 4/5
         then:
           - lambda: |-
               queueRequest(${target}, Property::k${property_wh});
@@ -73,6 +71,4 @@ time:
           - lambda: |-
               // set the current Wh value as offset for the next day and convert Wh to kWh
               id(gOFFSET_${property_wh}) = id(${property_wh}).raw_state * 0.001;
-          - sensor.template.publish:
-              id: ${sensor_name}
-              state: 0.0
+              id(${sensor_name}).publish_state(0.0);


### PR DESCRIPTION
For electrical power consumption readings the Wh values are not reset at midnight, which lead to problems an required a manual offset calculation for the next day. This approach is wrong for sensor values like "heating power sum day" where both values are reset at midnight. The offset could become negative and result in wrong COP values.

Fixes: #85