### PR TITLE
Hot water needs to be split into two entities

### DIFF
--- a/src/custom_climate.h
+++ b/src/custom_climate.h
@@ -104,12 +104,12 @@ class CustomClimate : public Component, public Climate {
     bool fanRunning{false};
 };
 
-class HeatingDayNight : public CustomClimate {
+class Heating : public CustomClimate {
    public:
     template <typename Sensor, typename BinarySensor>
-    HeatingDayNight(Sensor* current_temperature_sensor, Sensor* target_temperature_sensor, BinarySensor* heating_sensor,
-                    BinarySensor* cooling_sensor, BinarySensor* fan_sensor, const Property targetHeatingTemperature,
-                    const Property targetCoolingTemperature)
+    Heating(Sensor* current_temperature_sensor, Sensor* target_temperature_sensor, BinarySensor* heating_sensor,
+            BinarySensor* cooling_sensor, BinarySensor* fan_sensor, const Property targetHeatingTemperature,
+            const Property targetCoolingTemperature)
         : CustomClimate({climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_AUTO,
                          climate::CLIMATE_MODE_FAN_ONLY, climate::CLIMATE_MODE_OFF},
                         {climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_HOME, climate::CLIMATE_PRESET_AWAY},

--- a/src/property.h
+++ b/src/property.h
@@ -99,11 +99,11 @@ struct Property : public detail::Property {
     PROPERTY(WAERMEERTRAG_HEIZ_SUM_MWH, 0x0931, Type::et_double_val);
 
 #if defined(THZ_504) || defined(THZ_404) || defined(THZ_5_5_ECO)
-    PROPERTY(RAUMSOLLTEMP_I, 0x0005, Type::et_dec_val);
+    PROPERTY(RAUMSOLLTEMP_TAG, 0x0005, Type::et_dec_val);
     PROPERTY(RAUMSOLLTEMP_NACHT, 0x0008, Type::et_dec_val);
     PROPERTY(SAMMLERISTTEMP, 0x000d, Type::et_dec_val);
     PROPERTY(VORLAUFISTTEMP, 0x000f, Type::et_dec_val);
-    PROPERTY(EINSTELL_SPEICHERSOLLTEMP, 0x0013, Type::et_dec_val);
+    PROPERTY(SPEICHERSOLLTEMP_TAG, 0x0013, Type::et_dec_val);
     PROPERTY(PROGRAMMSCHALTER, 0x0112, Type::et_betriebsart);
     PROPERTY(HYSTERESE_WW, 0x0140, Type::et_dec_val);
     PROPERTY(BETRIEBS_STATUS, 0x0176);
@@ -137,6 +137,7 @@ struct Property : public detail::Property {
     PROPERTY(FORTLUFT_SOLL, 0x059a);
     PROPERTY(FORTLUFT_IST, 0x059b);
     PROPERTY(PUMPENZYKLEN_MIN_AUSSENT, 0x05bb);
+    PROPERTY(SPEICHERSOLLTEMP_NACHT, 0x05bf, Type::et_dec_val);
     PROPERTY(KUEHLSYSTEM, 0x0613);
     PROPERTY(DRUCK_HEIZKREIS, 0x064a, Type::et_dec_val);
     PROPERTY(LEISTUNG_AUSLEGUNG_KUEHLEN, 0x0692);

--- a/yaml/wp_base.yaml
+++ b/yaml/wp_base.yaml
@@ -174,7 +174,7 @@ sensor:
 climate:
   - platform: custom
     lambda: |-
-      auto heating = new HeatingDayNight(id(RAUMISTTEMP),id(RAUMSOLLTEMP_I), id(HEIZEN), id(KUEHLEN), id(LUEFTUNG), Property::kRAUMSOLLTEMP_I, Property::kKUEHL_RAUMSOLL_TAG);
+      auto heating = new Heating(id(RAUMISTTEMP),id(RAUMSOLLTEMP_TAG), id(HEIZEN), id(KUEHLEN), id(LUEFTUNG), Property::kRAUMSOLLTEMP_TAG, Property::kKUEHL_RAUMSOLL_TAG);
       App.register_component(heating);
       return {heating};
     climates:
@@ -188,7 +188,7 @@ climate:
 
   - platform: custom
     lambda: |-
-      auto heating = new HeatingDayNight(id(RAUMISTTEMP),id(RAUMSOLLTEMP_NACHT), id(HEIZEN), id(KUEHLEN), id(LUEFTUNG), Property::kRAUMSOLLTEMP_NACHT, Property::kKUEHL_RAUMSOLL_NACHT);
+      auto heating = new Heating(id(RAUMISTTEMP),id(RAUMSOLLTEMP_NACHT), id(HEIZEN), id(KUEHLEN), id(LUEFTUNG), Property::kRAUMSOLLTEMP_NACHT, Property::kKUEHL_RAUMSOLL_NACHT);
       App.register_component(heating);
       return {heating};
     climates:
@@ -202,11 +202,25 @@ climate:
 
   - platform: custom
     lambda: |-
-      auto hot_water = new HotWater(id(SPEICHERISTTEMP),id(EINSTELL_SPEICHERSOLLTEMP), id(WARMWASSERBEREITUNG), Property::kEINSTELL_SPEICHERSOLLTEMP);
+      auto hot_water = new HotWater(id(SPEICHERISTTEMP),id(SPEICHERSOLLTEMP_TAG), id(WARMWASSERBEREITUNG), Property::kSPEICHERSOLLTEMP_TAG);
       App.register_component(hot_water);
       return {hot_water};
     climates:
-      name: "Hot Water"
+      name: "Hot Water Day"
+      visual:
+        min_temperature: 30.0
+        max_temperature: 75.0
+        temperature_step:
+          target_temperature: 1.0
+          current_temperature: 0.1
+
+  - platform: custom
+    lambda: |-
+      auto hot_water = new HotWater(id(SPEICHERISTTEMP),id(SPEICHERSOLLTEMP_NACHT), id(WARMWASSERBEREITUNG), Property::kSPEICHERSOLLTEMP_NACHT);
+      App.register_component(hot_water);
+      return {hot_water};
+    climates:
+      name: "Hot Water Night"
       visual:
         min_temperature: 30.0
         max_temperature: 75.0
@@ -251,11 +265,12 @@ packages:
 
   WAERMEERTRAG_RUECKGE_SUMME_MWH:  !include { file: wp_generic_combined.yaml, vars: { sensor_name: "WAERMEERTRAG_RUECKGE_SUMME_MWH"     , scaled_property: "WAERMEERTRAG_RUECKGE_SUM_KWH" , property: "WAERMEERTRAG_RUECKGE_SUM_MWH" , unit: "MWh", accuracy_decimals: "3", icon: "mdi:fire"  }}
 
-  ABLUFTTEMP:                     !include { file: wp_temperature.yaml, vars: { property: "ABLUFTTEMP"                }}
-  EINSTELL_SPEICHERSOLLTEMP:      !include { file: wp_temperature.yaml, vars: { property: "EINSTELL_SPEICHERSOLLTEMP" }}
+  ABLUFTTEMP:                     !include { file: wp_temperature.yaml, vars: { property: "ABLUFTTEMP"             }}
+  SPEICHERSOLLTEMP_TAG:           !include { file: wp_temperature.yaml, vars: { property: "SPEICHERSOLLTEMP_TAG"   }}
+  SPEICHERSOLLTEMP_NACHT:         !include { file: wp_temperature.yaml, vars: { property: "SPEICHERSOLLTEMP_NACHT" }}
   SAMMLERISTTEMP:                 !include { file: wp_temperature.yaml, vars: { property: "SAMMLERISTTEMP"           , interval: $interval_medium }}
   TAUPUNKT_HK1:                   !include { file: wp_temperature.yaml, vars: { property: "TAUPUNKT_HK1"             , target: "HK1" }}
-  RAUMSOLLTEMP_I:                 !include { file: wp_temperature.yaml, vars: { property: "RAUMSOLLTEMP_I"           , target: "HK1" }}
+  RAUMSOLLTEMP_TAG:               !include { file: wp_temperature.yaml, vars: { property: "RAUMSOLLTEMP_TAG"         , target: "HK1" }}
   RAUMSOLLTEMP_NACHT:             !include { file: wp_temperature.yaml, vars: { property: "RAUMSOLLTEMP_NACHT"       , target: "HK1" }}
   KUEHL_RAUMSOLL_TAG:             !include { file: wp_temperature.yaml, vars: { property: "KUEHL_RAUMSOLL_TAG"       , target: "HK1" }}
 


### PR DESCRIPTION
https://github.com/kr0ner/OneESP32ToRuleThemAll/issues/50 already revealed that setting only one solltemp can lead to toggling behavior. Should've fixed it for hot water as well. If a schedule for hot water is active (not recommended) in the heat pump, there are two climate controllers needed to change the values, depending on the time of day.

Also fixed the namings since there should always be *SOLL_TAG & *SOLL_NACHT

