### PR TITLE
Handle external events properly

### DIFF
--- a/src/communication.h
+++ b/src/communication.h
@@ -146,6 +146,8 @@ void sendData(const CanMember& member, const Property property, const std::uint1
     data.insert(data.end(), {IdByte1, IdByte2, 0xfa, IndexByte1, IndexByte2, ValueByte1, ValueByte2});
 
     id(wp_can).send_data(ESPClient.canId, use_extended_id, data);
+    // directly request the value again to make sure the sensors are updated
+    queueRequest(member, property);
 }
 
 #endif

--- a/yaml/wp_base.yaml
+++ b/yaml/wp_base.yaml
@@ -267,14 +267,14 @@ packages:
   WAERMEERTRAG_2WE_WW_SUMME_MWH:   !include { file: wp_generic_combined.yaml, vars: { sensor_name: "WAERMEERTRAG_2WE_WW_SUMME_MWH"      , scaled_property: "WAERMEERTRAG_2WE_WW_SUM_KWH"  , property: "WAERMEERTRAG_2WE_WW_SUM_MWH"  , unit: "MWh", accuracy_decimals: "3", icon: "mdi:fire"  }}
   WAERMEERTRAG_2WE_HEIZ_SUMME_MWH: !include { file: wp_generic_combined.yaml, vars: { sensor_name: "WAERMEERTRAG_2WE_HEIZ_SUMME_MWH"    , scaled_property: "WAERMEERTRAG_2WE_HEIZ_SUM_KWH", property: "WAERMEERTRAG_2WE_HEIZ_SUM_MWH", unit: "MWh", accuracy_decimals: "3", icon: "mdi:fire"  }}
 
-  ABLUFTTEMP:                     !include { file: wp_temperature.yaml, vars: { property: "ABLUFTTEMP"             }}
-  SPEICHERSOLLTEMP_TAG:           !include { file: wp_temperature.yaml, vars: { property: "SPEICHERSOLLTEMP_TAG"   }}
-  SPEICHERSOLLTEMP_NACHT:         !include { file: wp_temperature.yaml, vars: { property: "SPEICHERSOLLTEMP_NACHT" }}
-  SAMMLERISTTEMP:                 !include { file: wp_temperature.yaml, vars: { property: "SAMMLERISTTEMP"           , update_interval: $interval_medium }}
-  TAUPUNKT_HK1:                   !include { file: wp_temperature.yaml, vars: { property: "TAUPUNKT_HK1"             , target: "HK1" }}
-  RAUMSOLLTEMP_TAG:               !include { file: wp_temperature.yaml, vars: { property: "RAUMSOLLTEMP_TAG"         , target: "HK1" }}
-  RAUMSOLLTEMP_NACHT:             !include { file: wp_temperature.yaml, vars: { property: "RAUMSOLLTEMP_NACHT"       , target: "HK1" }}
-  KUEHL_RAUMSOLL_TAG:             !include { file: wp_temperature.yaml, vars: { property: "KUEHL_RAUMSOLL_TAG"       , target: "HK1" }}
+  ABLUFTTEMP:                     !include { file: wp_temperature.yaml, vars: { property: "ABLUFTTEMP"  }}
+  SPEICHERSOLLTEMP_TAG:           !include { file: wp_temperature.yaml, vars: { property: "SPEICHERSOLLTEMP_TAG"   , writable: "true" }}
+  SPEICHERSOLLTEMP_NACHT:         !include { file: wp_temperature.yaml, vars: { property: "SPEICHERSOLLTEMP_NACHT" , writable: "true" }}
+  SAMMLERISTTEMP:                 !include { file: wp_temperature.yaml, vars: { property: "SAMMLERISTTEMP"         , update_interval: $interval_medium }}
+  TAUPUNKT_HK1:                   !include { file: wp_temperature.yaml, vars: { property: "TAUPUNKT_HK1"           , target: "HK1" }}
+  RAUMSOLLTEMP_TAG:               !include { file: wp_temperature.yaml, vars: { property: "RAUMSOLLTEMP_TAG"       , target: "HK1" , writable: "true" }}
+  RAUMSOLLTEMP_NACHT:             !include { file: wp_temperature.yaml, vars: { property: "RAUMSOLLTEMP_NACHT"     , target: "HK1" , writable: "true" }}
+  KUEHL_RAUMSOLL_TAG:             !include { file: wp_temperature.yaml, vars: { property: "KUEHL_RAUMSOLL_TAG"     , target: "HK1" , writable: "true" }}
 
   LUEFT_STUFE_TAG:                !include { file: wp_ventilation.yaml, vars: { property: "LUEFT_STUFE_TAG"   }}
   LUEFT_STUFE_NACHT:              !include { file: wp_ventilation.yaml, vars: { property: "LUEFT_STUFE_NACHT" }}

--- a/yaml/wp_number.yaml
+++ b/yaml/wp_number.yaml
@@ -37,7 +37,8 @@ esphome:
     priority: -100
     then:
       - lambda: |-
-          CallbackHandler::instance().addCallback(std::make_pair(${target},Property::k${property}),[](const SimpleVariant& value){
+          CallbackHandler::instance().addCallbacks({std::make_pair(${target},Property::k${property}),
+                                                    std::make_pair(Manager,Property::k${property})},[](const SimpleVariant& value){
               id(${property}).publish_state(value);
           });
           queueRequest(${target}, Property::k${property});

--- a/yaml/wp_temperature.yaml
+++ b/yaml/wp_temperature.yaml
@@ -1,6 +1,7 @@
 defaults:
   update_interval: $interval_very_slow
   target: "Kessel"
+  writable: "false"
 
 sensor:
   - platform: template
@@ -21,7 +22,11 @@ esphome:
     priority: -100
     then:
       - lambda: |-
-          CallbackHandler::instance().addCallback(std::make_pair(${target},Property::k${property}),[](const SimpleVariant& value){
+          auto callback= [](const SimpleVariant& value){
               id(${property}).publish_state(value);
-          });
+          };
+          CallbackHandler::instance().addCallback(std::make_pair(${target},Property::k${property}),callback);
+          if constexpr(${writable}) {
+            CallbackHandler::instance().addCallback(std::make_pair(Manager,Property::k${property}),callback);
+          }
           queueRequest(${target}, Property::k${property});

--- a/yaml/wp_ventilation.yaml
+++ b/yaml/wp_ventilation.yaml
@@ -29,7 +29,8 @@ esphome:
     priority: -100
     then:
       - lambda: |-
-          CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::k${property}),[](const SimpleVariant& value){
+          CallbackHandler::instance().addCallbacks({std::make_pair(Kessel,Property::k${property}),
+                                                   std::make_pair(Manager,Property::k${property})},[](const SimpleVariant& value){
               const auto fan_speed = std::min(static_cast<std::uint16_t>(3U),static_cast<std::uint16_t>(value));
               // only speeds between 1 and speed_count are allowed
               if(fan_speed == 0) {


### PR DESCRIPTION
The current implementation relies on polling the values in order to keep the sensors up to date. If the heat pump is being controlled via the display, it takes up to <interval_time> to reflect the change in HA user interface. For this to work we nee to add another callback that handles this use case, but only for values that can be actively changed. The second use case is when updating settings from within HA. Also here we'd require some time until the values are polled and updated again. We can improve the situation by querying the sensor value every time an update request is sent to the heatpump.

Closes: https://github.com/kr0ner/OneESP32ToRuleThemAll/issues/94