### PR TITLE
Adds the possibility to have conditional requests

### DIFF
--- a/yaml/common.yaml
+++ b/yaml/common.yaml
@@ -83,11 +83,15 @@ interval:
     then:
       - lambda: |-
           // Request sensor value one after another.
-          if(!request_queue.empty()) {
-            constexpr auto use_extended_id{false};
-            const auto request_element = request_queue.front();
-            request_queue.pop();
-            requestData(request_element.first, request_element.second);
+          if(!conditionalRequests.empty()) {
+            // find the next request of which the condition evaluates to true
+            auto it = std::find_if(conditionalRequests.begin(),conditionalRequests.end(),[](const auto& element){
+              return element._condition();
+            });
+            if(it != conditionalRequests.end()) {
+                requestData(it->_request.first, it->_request.second);
+                conditionalRequests.erase(it);
+            }
           }
   - interval: $interval_medium
     then:

--- a/yaml/wp_number.yaml
+++ b/yaml/wp_number.yaml
@@ -16,7 +16,7 @@ number:
     optimistic: true
     set_action:
       - lambda: |-
-          ESP_LOGI("Number", "New value %f", x);
+          ESP_LOGI("Number", "Setting new value %f for %s", x, std::string(Property::k${property}.name).c_str());
           if(x != NAN) {
             const auto type = Property::k${property}.type;
             switch(type) {


### PR DESCRIPTION
Condition can be anything and once it evaluates to true will trigger the request of a property from a CAN member. Default condition is always true and leads to immediate request. In context of re-reading the updated values, it is used to request the data 10 seconds in the future.