### PR TITLE
Add missing chrono include

### DIFF
--- a/src/communication.h
+++ b/src/communication.h
@@ -1,5 +1,6 @@
 #if !defined(COMMUNICATION_H)
 #define COMMUNICATION_H
+#include <chrono>
 #include <cstdint>
 #include <list>
 #include <string>


### PR DESCRIPTION
If sml_reader.h is not included the build fails as communication.h is using chrono but does not include it