### PR TITLE
Drop more log messages with INFO

### DIFF
--- a/src/communication.h
+++ b/src/communication.h
@@ -145,13 +145,16 @@ std::pair<Property, SimpleVariant> processCanMessage(const std::vector<std::uint
 
     const auto value{static_cast<std::uint16_t>((byte1 << 8U) | byte2)};
     const auto canId{static_cast<std::uint16_t>(((msg[0U] & 0xfc) << 3) | (msg[1U] & 0x3f))};
+    if (isRequest(msg)) {
+        ESP_LOGD("Communication", "Message is a request. Dropping it!");
+        ESP_LOGD("Communication",
+                 "Message received: Read/Write ID 0x%02x 0x%02x(0x%03x) for property %s (0x%04x) with raw value: %d",
+                 msg[0U], msg[1U], canId, std::string(property.name).c_str(), property.id, value);
+        return {Property::kINDEX_NOT_FOUND, value};
+    }
     ESP_LOGI("Communication",
              "Message received: Read/Write ID 0x%02x 0x%02x(0x%03x) for property %s (0x%04x) with raw value: %d",
              msg[0U], msg[1U], canId, std::string(property.name).c_str(), property.id, value);
-    if (isRequest(msg)) {
-        ESP_LOGD("Communication", "Message is a request. Dropping it!");
-        return {Property::kINDEX_NOT_FOUND, value};
-    }
     return {property, GetValueByType(value, property.type)};
 }
 

--- a/yaml/wp_datetime.yaml
+++ b/yaml/wp_datetime.yaml
@@ -28,6 +28,7 @@ esphome:
                 timeToSet.month = static_cast<std::uint16_t>(value);
               });
             });
+            CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kWOCHENTAG),[](const SimpleVariant&){});
             CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kTAG),[updateTime](const SimpleVariant& value){
               updateTime([&value](ESPTime& timeToSet){
                 timeToSet.day_of_month = static_cast<std::uint16_t>(value);


### PR DESCRIPTION
No need to spam the log output when requests are dropped anyway. Only print the content with DEBUG.

Added empty callback for kWOCHENTAG to not spam.