### PR TITLE
Prevent turning of switches after reboot

### DIFF
--- a/yaml/wp_switch.yaml
+++ b/yaml/wp_switch.yaml
@@ -7,6 +7,7 @@ switch:
     name: ${property}
     id: ${property}
     icon: ${icon}
+    restore_mode: RESTORE_DEFAULT_OFF
     turn_on_action:
       - lambda: |-
           sendData(${target}, Property::k${property}, static_cast<std::uint16_t>(true));


### PR DESCRIPTION
After reboot the default "off" was loaded, which actively turned off all the switches that were configured (cooling, WW_ECO). This is not intendend bevavior.

Closes: #177

Thanks @zimbo86 for the fix :heart_hands: 