### PR TITLE
Request ABLUFT/ZULUFT_IST more often

### DIFF
--- a/src/custom_climate.h
+++ b/src/custom_climate.h
@@ -9,9 +9,12 @@ class CustomClimate : public Component, public Climate {
         traits_.set_supported_modes(std::move(modes));
         traits_.set_supported_presets(std::move(presets));
         traits_.set_supports_current_temperature(true);
+        update_mode();
     }
 
     void setup() override {}
+
+    float get_setup_priority() const override { return esphome::setup_priority::LATE; }
 
     template <typename Sensor>
     void register_current_temperature_callback(Sensor* current_temperature_sensor) {

--- a/yaml/ttf07.yaml
+++ b/yaml/ttf07.yaml
@@ -3,7 +3,7 @@ esphome:
     build_flags:
       - "-DTTF_07_C"
   on_boot:
-    priority: -100
+    priority: 100.0 # AFTER_CONNECTION
     then:
       - lambda: |-
           CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kPROGRAMMSCHALTER),[](const SimpleVariant& value){

--- a/yaml/wp_base.yaml
+++ b/yaml/wp_base.yaml
@@ -2,7 +2,7 @@ esphome:
   includes:
     - OneESP32ToRuleThemAll/src/custom_climate.h
   on_boot:
-    priority: -100
+    priority: 100.0 # AFTER_CONNECTION
     then:
       - lambda: |-
           CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kPASSIVKUEHLUNG),[](const SimpleVariant& value){
@@ -12,13 +12,14 @@ esphome:
               id(PASSIVKUEHLUNG).publish_state(stringValue);
             }
           });
-          queueRequest(Kessel, Property::kPASSIVKUEHLUNG);
+          scheduleRequest(Kessel, Property::kPASSIVKUEHLUNG, std::chrono::seconds(10));
 
           CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kZULUFT_IST),[](const SimpleVariant& value){
             // workaround for broken ninth bit of BETRIEBSSTATUS
             const auto zuluftIst = static_cast<std::uint16_t>(value);
             id(LUEFTUNG).publish_state(zuluftIst > 0U);
           });
+          scheduleRequest(Kessel, Property::kZULUFT_IST, std::chrono::seconds(10));
 
           CallbackHandler::instance().addCallbacks({std::make_pair(Kessel,Property::kABLUFT_SOLL),
                                                     std::make_pair(Kessel,Property::kZULUFT_SOLL)},
@@ -51,14 +52,14 @@ esphome:
               id(PROGRAMMSCHALTER).publish_state(stringValue);
             }
           });
-          queueRequest(Kessel, Property::kPROGRAMMSCHALTER);
+          scheduleRequest(Kessel, Property::kPROGRAMMSCHALTER, std::chrono::seconds(10));
 
           CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kBETRIEBS_STATUS_2),[](const SimpleVariant& value){
             const std::bitset<2U> status_bits{static_cast<std::uint16_t>(value)};
             id(SOMMERBETRIEB_AKTIV).publish_state(status_bits.test(0U));
             id(OFEN_KAMIN_AKTIV).publish_state(status_bits.test(1U));
           });
-          queueRequest(Kessel, Property::kBETRIEBS_STATUS_2);
+          scheduleRequest(Kessel, Property::kBETRIEBS_STATUS_2, std::chrono::seconds(10));
 
           CallbackHandler::instance().addCallback(std::make_pair(Kessel,Property::kBETRIEBS_STATUS),[](const SimpleVariant& value){
             const std::bitset<15U> status_bits{static_cast<std::uint16_t>(value)};
@@ -78,7 +79,7 @@ esphome:
             id(FILTERWECHSEL_ZULUFT).publish_state(status_bits.test(13U));
             id(AUFHEIZPROGRAMM_AKTIV).publish_state(status_bits.test(14U));
           });
-          queueRequest(Kessel, Property::kBETRIEBS_STATUS);
+          scheduleRequest(Kessel, Property::kBETRIEBS_STATUS, std::chrono::seconds(10));
 
 #########################################
 #                                       #

--- a/yaml/wp_daily_energy_combined.yaml
+++ b/yaml/wp_daily_energy_combined.yaml
@@ -34,7 +34,7 @@ sensor:
 
 esphome:
   on_boot:
-    priority: -100
+    priority: 100.0 # AFTER_CONNECTION
     then:
       - lambda: |-
           // Handle the values received from the heat pump. Wh value is just stored in an internal sensor and published together with the kWh value on reception.

--- a/yaml/wp_datetime.yaml
+++ b/yaml/wp_datetime.yaml
@@ -1,6 +1,6 @@
 esphome:
   on_boot:
-    priority: -100
+    priority: 100.0 # AFTER_CONNECTION
     then:
       - lambda: |-
             id(HEATPUMP_DATETIME).state = "2024-01-01 12:34";

--- a/yaml/wp_generic.yaml
+++ b/yaml/wp_generic.yaml
@@ -22,7 +22,7 @@ sensor:
 
 esphome:
   on_boot:
-    priority: -100
+    priority: 100.0 # AFTER_CONNECTION
     then:
       - lambda: |-
           CallbackHandler::instance().addCallback(std::make_pair(${target},Property::k${property}),[](const SimpleVariant& value){

--- a/yaml/wp_generic_combined.yaml
+++ b/yaml/wp_generic_combined.yaml
@@ -28,7 +28,7 @@ sensor:
 
 esphome:
   on_boot:
-    priority: -100
+    priority: 100.0 # AFTER_CONNECTION
     then:
       - lambda: |-
           // Handle the values received from the heat pump. Scaled property value is just stored in an internal sensor and published together with the property value on reception.

--- a/yaml/wp_number.yaml
+++ b/yaml/wp_number.yaml
@@ -34,7 +34,7 @@ number:
 
 esphome:
   on_boot:
-    priority: -100
+    priority: 100.0 # AFTER_CONNECTION
     then:
       - lambda: |-
           CallbackHandler::instance().addCallbacks({std::make_pair(${target},Property::k${property}),

--- a/yaml/wp_switch.yaml
+++ b/yaml/wp_switch.yaml
@@ -17,7 +17,7 @@ switch:
 
 esphome:
   on_boot:
-    priority: -100
+    priority: 100.0 # AFTER_CONNECTION
     then:
       - lambda: |-
           static_assert(Property::k${property}.type == Type::et_bool, "Only properties of type bool are supported by wp_switch.");

--- a/yaml/wp_temperature.yaml
+++ b/yaml/wp_temperature.yaml
@@ -21,7 +21,7 @@ sensor:
 
 esphome:
   on_boot:
-    priority: -100
+    priority: 100.0 # AFTER_CONNECTION
     then:
       - lambda: |-
           auto callback= [](const SimpleVariant& value){

--- a/yaml/wp_ventilation.yaml
+++ b/yaml/wp_ventilation.yaml
@@ -9,24 +9,30 @@ fan:
           const auto fan_speed = std::min(3, x);
           ESP_LOGI("fan", "Speed set %d", fan_speed);
           sendData(Kessel, Property::k${property}, fan_speed);
-          queueRequest(Kessel, Property::kZULUFT_SOLL);
-          queueRequest(Kessel, Property::kABLUFT_SOLL);
+          scheduleRequest(Kessel, Property::kZULUFT_SOLL, std::chrono::seconds(10));
+          scheduleRequest(Kessel, Property::kZULUFT_IST, std::chrono::seconds(20));
+          scheduleRequest(Kessel, Property::kABLUFT_SOLL, std::chrono::seconds(10));
+          scheduleRequest(Kessel, Property::kABLUFT_IST, std::chrono::seconds(20));
     on_turn_off:
       - lambda: |-
           ESP_LOGI("fan", "Fan turned off!");
           sendData(Kessel, Property::k${property}, 0U);
-          queueRequest(Kessel, Property::kZULUFT_SOLL);
-          queueRequest(Kessel, Property::kABLUFT_SOLL);
+          scheduleRequest(Kessel, Property::kZULUFT_SOLL, std::chrono::seconds(10));
+          scheduleRequest(Kessel, Property::kZULUFT_IST, std::chrono::seconds(20));
+          scheduleRequest(Kessel, Property::kABLUFT_SOLL, std::chrono::seconds(10));
+          scheduleRequest(Kessel, Property::kABLUFT_IST, std::chrono::seconds(20));
     on_turn_on:
       - lambda: |-
           ESP_LOGI("fan", "Fan turned on!");
           sendData(Kessel, Property::k${property}, id(${property}).speed);
-          queueRequest(Kessel, Property::kZULUFT_SOLL);
-          queueRequest(Kessel, Property::kABLUFT_SOLL);
+          scheduleRequest(Kessel, Property::kZULUFT_SOLL, std::chrono::seconds(10));
+          scheduleRequest(Kessel, Property::kZULUFT_IST, std::chrono::seconds(20));
+          scheduleRequest(Kessel, Property::kABLUFT_SOLL, std::chrono::seconds(10));
+          scheduleRequest(Kessel, Property::kABLUFT_IST, std::chrono::seconds(20));
 
 esphome:
   on_boot:
-    priority: -100
+    priority: 100.0 # AFTER_CONNECTION
     then:
       - lambda: |-
           CallbackHandler::instance().addCallbacks({std::make_pair(Kessel,Property::k${property}),

--- a/yaml/wpl13.yaml
+++ b/yaml/wpl13.yaml
@@ -19,7 +19,7 @@ esphome:
       - "-DHK1_ID=$hk1_can_id"
       - "-DHK2_ID=$hk2_can_id"
   on_boot:
-    priority: -100
+    priority: 100.0 # AFTER_CONNECTION
     then:
       - lambda: |-
           CallbackHandler::instance().addCallback(std::make_pair(WPM2,Property::kPROGRAMMSCHALTER),[](const SimpleVariant& value){


### PR DESCRIPTION
With this change the state of the heatpump is better reflected by the custom climates. Also a more conservative approach with a delay of 10 seconds is used to give the heatpump some time to adjust the values.

Fixes: #181