### PR TITLE
New Valvue thz55eco ZEITSPERRE NE

### DIFF
--- a/src/property.h
+++ b/src/property.h
@@ -175,6 +175,7 @@ struct Property : public oe32trta::detail::Property {
     PROPERTY(LAUFZEIT_FILTER, 0xc111);
     PROPERTY(DIFFERENZDRUCK, 0xc11e);
     PROPERTY(BETRIEBS_STATUS_2, 0xc356);
+    PROPERTY(ZEITSPERRE_NE, 0x0588);
 #endif
 
 #if defined(TTF_07_C)

--- a/yaml/thz5_5_eco.yaml
+++ b/yaml/thz5_5_eco.yaml
@@ -12,3 +12,4 @@ packages:
 
   LAUFZEIT_FILTER_TAGE:     !include { file: wp_generic.yaml, vars: { property: "LAUFZEIT_FILTER_TAGE" , icon: "mdi:air-filter"      , unit: "d" , update_interval: $interval_once_in_a_while }}
   SOMMERBETRIEB_TEMP:       !include { file: wp_number.yaml , vars: { property: "SOMMERBETRIEB_TEMP"   , icon: "mdi:sun-thermometer" , unit: "°C", min: "15.0", max: "25.0", step: "1.0"      }}
+  ZEITSPERRE_NE:            !include { file: wp_number.yaml , vars: { property: "ZEITSPERRE_NE"   , icon: "mdi:valve" , min: "0", max: "360", step: "5.0"      }}


### PR DESCRIPTION
I control the heating elements via NOTBETRIEB. Due to the value in standard mode, the heating elements only turn on after 90 minutes.

The value can then be set lower via automation to usually wait 90 minutes.