### PR TITLE
Properly convert type when sending via CAN

### DIFF
--- a/src/mapper.cpp
+++ b/src/mapper.cpp
@@ -5,6 +5,15 @@ std::optional<std::string> Mapper::getError(const std::uint16_t id) const {
     return (it != errorMap.cend()) ? std::make_optional(it->second) : std::nullopt;
 }
 
+std::optional<std::uint16_t> Mapper::getErrorId(const std::string& error) const {
+    for (const auto& element : errorMap) {
+        if (element.second == error) {
+            return element.first;
+        }
+    }
+    return {};
+}
+
 std::optional<std::string> Mapper::getBetriebsart(const std::uint16_t id) const {
     const auto it = betriebsartMap.find(id);
     return (it != betriebsartMap.cend()) ? std::make_optional(it->second) : std::nullopt;

--- a/src/mapper.h
+++ b/src/mapper.h
@@ -13,6 +13,8 @@ class Mapper {
    public:
     std::optional<std::string> getError(const std::uint16_t id) const;
 
+    std::optional<std::uint16_t> getErrorId(const std::string& error) const;
+
     std::optional<std::string> getBetriebsart(const std::uint16_t id) const;
 
     std::optional<std::uint16_t> getBetriebsartId(const std::string& betriebsart) const;

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -18,7 +18,7 @@
 #include "type.h"
 
 #include <algorithm>
-#include <cstring>
+#include <string>
 
 #include "mapper.h"
 
@@ -93,6 +93,163 @@ SimpleVariant GetValueByType(const std::uint16_t value, const Type type) {
             [[fallthrough]];
         default:
             return value;
+    }
+}
+
+std::optional<uint16_t> GetRawByType(const SimpleVariant& value, Type type) {
+    switch (type) {
+        case Type::et_byte: {
+            if (!value.holds_alternative<float>()) {
+                return std::nullopt;
+            }
+            return static_cast<uint16_t>(value.get<float>());
+        }
+
+        case Type::et_dec_val: {
+            if (!value.holds_alternative<float>()) {
+                return std::nullopt;
+            }
+            return static_cast<uint16_t>(static_cast<int16_t>(value.get<float>() * 10.0f));
+        }
+
+        case Type::et_cent_val: {
+            if (!value.holds_alternative<float>()) {
+                return std::nullopt;
+            }
+            return static_cast<uint16_t>(static_cast<int16_t>(value.get<float>() * 100.0f));
+        }
+
+        case Type::et_mil_val: {
+            if (!value.holds_alternative<float>()) {
+                return std::nullopt;
+            }
+            return static_cast<uint16_t>(static_cast<int16_t>(value.get<float>() * 1000.0f));
+        }
+
+        case Type::et_little_endian: {
+            if (!value.holds_alternative<float>()) {
+                return std::nullopt;
+            }
+            uint16_t i = static_cast<uint16_t>(value.get<float>());
+            return static_cast<uint16_t>(((i >> 8U) & 0xFF) | ((i & 0xFF) << 8U));
+        }
+
+        case Type::et_little_bool: {
+            if (!value.holds_alternative<bool>()) {
+                return std::nullopt;
+            }
+            return value.get<bool>() ? 0x0100u : 0x0000u;
+        }
+
+        case Type::et_bool: {
+            if (!value.holds_alternative<bool>()) {
+                return std::nullopt;
+            }
+            return value.get<bool>() ? 0x0001u : 0x0000u;
+        }
+
+        case Type::et_betriebsart: {
+            if (!value.holds_alternative<std::string>()) {
+                return std::nullopt;
+            }
+            const auto& s = value.get<std::string>();
+            const auto result = Mapper::instance().getBetriebsartId(s);
+            if (!result.has_value()) {
+                return std::nullopt;
+            }
+#if defined(WPL_13)
+            return static_cast<uint16_t>(result.value() >> 8U);
+#else
+            return result;
+#endif
+        }
+
+        case Type::et_zeit: {
+            if (!value.holds_alternative<std::string>()) {
+                return std::nullopt;
+            }
+            const auto& s = value.get<std::string>();
+            int hour = 0, minute = 0;
+            if (sscanf(s.c_str(), "%d:%d", &hour, &minute) != 2) {
+                return std::nullopt;
+            }
+            return static_cast<uint16_t>(((hour & 0xFF) << 8U) | (minute & 0xFF));
+        }
+
+        case Type::et_datum: {
+            if (!value.holds_alternative<std::string>()) {
+                return std::nullopt;
+            }
+            const auto& s = value.get<std::string>();
+            int day = 0, month = 0;
+            if (sscanf(s.c_str(), "%d.%d.", &day, &month) != 2) {
+                return std::nullopt;
+            }
+            return static_cast<uint16_t>(((day & 0xFF) << 8U) | (month & 0xFF));
+        }
+
+        case Type::et_time_domain: {
+            if (!value.holds_alternative<std::string>()) {
+                return std::nullopt;
+            }
+            const auto& s = value.get<std::string>();
+            int h1 = 0, m1 = 0, h2 = 0, m2 = 0;
+            if (sscanf(s.c_str(), "%d:%d-%d:%d", &h1, &m1, &h2, &m2) != 4) {
+                return std::nullopt;
+            }
+            uint8_t left = static_cast<uint8_t>(4 * h1 + (m1 / 15));
+            uint8_t right = static_cast<uint8_t>(4 * h2 + (m2 / 15));
+            return static_cast<uint16_t>((left << 8U) | right);
+        }
+
+        case Type::et_dev_nr: {
+            if (!value.holds_alternative<std::string>()) {
+                return std::nullopt;
+            }
+            const auto& s = value.get<std::string>();
+            if (s == "--") {
+                return static_cast<uint16_t>(0x80u);
+            }
+            int n = atoi(s.c_str());
+            if (n <= 0) {
+                return std::nullopt;
+            }
+            return static_cast<uint16_t>(n - 1);
+        }
+
+        case Type::et_dev_id: {
+            if (!value.holds_alternative<std::string>()) {
+                return std::nullopt;
+            }
+            const auto& s = value.get<std::string>();
+            int a = 0, b = 0;
+            if (sscanf(s.c_str(), "%d-%d", &a, &b) != 2) {
+                return std::nullopt;
+            }
+            return static_cast<uint16_t>(((a & 0xFF) << 8U) | (b & 0xFF));
+        }
+
+        case Type::et_err_nr: {
+            if (!value.holds_alternative<std::string>()) {
+                return std::nullopt;
+            }
+            const auto& s = value.get<std::string>();
+            const auto result = Mapper::instance().getErrorId(s);
+            if (!result.has_value()) {
+                return std::nullopt;
+            }
+            return result;
+        }
+
+        case Type::et_double_val:
+        case Type::et_triple_val:
+        case Type::et_default:
+        default: {
+            if (!value.holds_alternative<float>()) {
+                return std::nullopt;
+            }
+            return static_cast<uint16_t>(static_cast<int16_t>(value.get<float>()));
+        }
     }
 }
 

--- a/src/type.h
+++ b/src/type.h
@@ -2,6 +2,7 @@
 #define TYPE_H
 
 #include <cstdint>
+#include <optional>
 #include "simple_variant.h"
 
 enum Type : std::uint8_t {
@@ -36,6 +37,13 @@ T getParamType(void (C::*)(T));
  *        returned as \c SimpleVariant.
  */
 SimpleVariant GetValueByType(const std::uint16_t value, const Type type);
+
+/**
+ * @brief Converts a typed \c SimpleVariant to its raw 16-bit representation.
+ *
+ * Inverse of GetValueByType(). Returns \c std::nullopt on conversion failure.
+ */
+std::optional<std::uint16_t> GetRawByType(const SimpleVariant& value, const Type type);
 
 /**
  * @brief Toggles endianness of an unsigned 16-bit integer.

--- a/yaml/common.yaml
+++ b/yaml/common.yaml
@@ -187,7 +187,8 @@ api:
 #########################################
 sensor:
   - platform: homeassistant
-    name: "Temperature Sensor From Home Assistant"
+    name: Temperature Sensor From Home Assistant
+    id: ha_temperature_sensor
     entity_id: $entity_room_temperature
     on_value:
       then:
@@ -196,7 +197,8 @@ sensor:
             id(gRAUMISTTEMP) = x;
 
   - platform: homeassistant
-    name: "Humidity Sensor From Home Assistant"
+    name: Humidity Sensor From Home Assistant
+    id: ha_humidity_sensor
     entity_id: $entity_humidity
     on_value:
       then:

--- a/yaml/thz404.yaml
+++ b/yaml/thz404.yaml
@@ -6,3 +6,5 @@ esphome:
 packages:
   COMMON: !include { file: common.yaml }
   BASE:   !include { file: wp_base.yaml }
+
+  SOMMERBETRIEB_TEMP:   !include { file: wp_number.yaml, vars: { property: "SOMMERBETRIEB_TEMP" , min: "10.0", max: "25.0" , step: "0.5" , unit: "°C" , icon: "mdi:sun-thermometer" }}

--- a/yaml/thz504.yaml
+++ b/yaml/thz504.yaml
@@ -8,5 +8,8 @@ packages:
   BASE:   !include { file: wp_base.yaml }
 
   ABLUFT_TAUPUNKT:      !include { file: wp_temperature.yaml, vars: { property: "ABLUFT_TAUPUNKT" }}
+
+  SOMMERBETRIEB_TEMP:   !include { file: wp_number.yaml, vars: { property: "SOMMERBETRIEB_TEMP" , min: "10.0", max: "25.0" , step: "0.5" , unit: "°C" , icon: "mdi:sun-thermometer" }}
+
   DIFFERENZDRUCK:       !include { file: wp_generic.yaml, vars: { property: "DIFFERENZDRUCK"      , icon: "mdi:air-filter", unit: "Pa", update_interval: $interval_medium          }}
   LAUFZEIT_FILTER_TAGE: !include { file: wp_generic.yaml, vars: { property: "LAUFZEIT_FILTER_TAGE", icon: "mdi:air-filter", unit: "d" , update_interval: $interval_once_in_a_while }}

--- a/yaml/thz5_5_eco.yaml
+++ b/yaml/thz5_5_eco.yaml
@@ -10,6 +10,7 @@ packages:
   LUEFT_STUFE_BEREITSCHAFT: !include { file: wp_ventilation.yaml, vars: { property: "LUEFT_STUFE_BEREITSCHAFT" }}
   LUEFT_STUFE_HAND:         !include { file: wp_ventilation.yaml, vars: { property: "LUEFT_STUFE_HAND"         }}
 
-  LAUFZEIT_FILTER_TAGE:     !include { file: wp_generic.yaml, vars: { property: "LAUFZEIT_FILTER_TAGE" , icon: "mdi:air-filter"      , unit: "d" , update_interval: $interval_once_in_a_while }}
-  SOMMERBETRIEB_TEMP:       !include { file: wp_number.yaml , vars: { property: "SOMMERBETRIEB_TEMP"   , icon: "mdi:sun-thermometer" , unit: "°C", min: "15.0", max: "25.0", step: "1.0"      }}
-  ZEITSPERRE_NE:            !include { file: wp_number.yaml , vars: { property: "ZEITSPERRE_NE"   , icon: "mdi:valve" , min: "0", max: "360", step: "5.0"      }}
+  LAUFZEIT_FILTER_TAGE:     !include { file: wp_generic.yaml, vars: { property: "LAUFZEIT_FILTER_TAGE" , icon: "mdi:air-filter" , unit: "d" , update_interval: $interval_once_in_a_while }}
+
+  SOMMERBETRIEB_TEMP:       !include { file: wp_number.yaml , vars: { property: "SOMMERBETRIEB_TEMP"   , icon: "mdi:sun-thermometer" , unit: "°C", min: "5.0", max: "25.0", step: "1.0" }}
+  ZEITSPERRE_NE:            !include { file: wp_number.yaml , vars: { property: "ZEITSPERRE_NE" , icon: "mdi:valve" , min: "0", max: "360", step: "5.0" }}

--- a/yaml/wp_base.yaml
+++ b/yaml/wp_base.yaml
@@ -290,13 +290,13 @@ packages:
   LEISTUNG_AUSLEGUNG_HEIZUNG:          !include { file: wp_number.yaml, vars: { property: "LEISTUNG_AUSLEGUNG_HEIZUNG" , min: "40", max: "100"}}
   LEISTUNG_AUSLEGUNG_KUEHLEN:          !include { file: wp_number.yaml, vars: { property: "LEISTUNG_AUSLEGUNG_KUEHLEN" , min: "30", max: "50" }}
   PUMPENDREHZAHL_HEIZEN:               !include { file: wp_number.yaml, vars: { property: "PUMPENDREHZAHL_HEIZEN"      , step: "0.1" }}
-  HYSTERESE_WW:                        !include { file: wp_number.yaml, vars: { property: "HYSTERESE_WW"               , min: "2.0", max: "10.0", step: "0.1", unit: "°C" }}
-  LUEFT_ZULUFT_STUFE1:                 !include { file: wp_number.yaml, vars: { property: "LUEFT_ZULUFT_STUFE1", min: "0.0", max: "300.0", unit: "m³/h", icon: "mdi:air-filter"  }}
-  LUEFT_ZULUFT_STUFE2:                 !include { file: wp_number.yaml, vars: { property: "LUEFT_ZULUFT_STUFE2", min: "0.0", max: "300.0", unit: "m³/h", icon: "mdi:air-filter"  }}
-  LUEFT_ZULUFT_STUFE3:                 !include { file: wp_number.yaml, vars: { property: "LUEFT_ZULUFT_STUFE3", min: "0.0", max: "300.0", unit: "m³/h", icon: "mdi:air-filter"  }}
-  LUEFT_ABLUFT_STUFE1:                 !include { file: wp_number.yaml, vars: { property: "LUEFT_ABLUFT_STUFE1", min: "0.0", max: "300.0", unit: "m³/h", icon: "mdi:air-filter"  }}
-  LUEFT_ABLUFT_STUFE2:                 !include { file: wp_number.yaml, vars: { property: "LUEFT_ABLUFT_STUFE2", min: "0.0", max: "300.0", unit: "m³/h", icon: "mdi:air-filter"  }}
-  LUEFT_ABLUFT_STUFE3:                 !include { file: wp_number.yaml, vars: { property: "LUEFT_ABLUFT_STUFE3", min: "0.0", max: "300.0", unit: "m³/h", icon: "mdi:air-filter"  }}
+  HYSTERESE_WW:                        !include { file: wp_number.yaml, vars: { property: "HYSTERESE_WW"               , min: "2.0",  max: "10.0" , step: "0.1" , unit: "°C" }}
+  LUEFT_ZULUFT_STUFE1:                 !include { file: wp_number.yaml, vars: { property: "LUEFT_ZULUFT_STUFE1"        , min: "0.0",  max: "300.0", unit: "m³/h", icon: "mdi:air-filter"  }}
+  LUEFT_ZULUFT_STUFE2:                 !include { file: wp_number.yaml, vars: { property: "LUEFT_ZULUFT_STUFE2"        , min: "0.0",  max: "300.0", unit: "m³/h", icon: "mdi:air-filter"  }}
+  LUEFT_ZULUFT_STUFE3:                 !include { file: wp_number.yaml, vars: { property: "LUEFT_ZULUFT_STUFE3"        , min: "0.0",  max: "300.0", unit: "m³/h", icon: "mdi:air-filter"  }}
+  LUEFT_ABLUFT_STUFE1:                 !include { file: wp_number.yaml, vars: { property: "LUEFT_ABLUFT_STUFE1"        , min: "0.0",  max: "300.0", unit: "m³/h", icon: "mdi:air-filter"  }}
+  LUEFT_ABLUFT_STUFE2:                 !include { file: wp_number.yaml, vars: { property: "LUEFT_ABLUFT_STUFE2"        , min: "0.0",  max: "300.0", unit: "m³/h", icon: "mdi:air-filter"  }}
+  LUEFT_ABLUFT_STUFE3:                 !include { file: wp_number.yaml, vars: { property: "LUEFT_ABLUFT_STUFE3"        , min: "0.0",  max: "300.0", unit: "m³/h", icon: "mdi:air-filter"  }}
 
   WAERMEERTRAG_RUECKGE_TAG_SUMME_KWH:  !include { file: wp_daily_energy_combined.yaml, vars: { sensor_name: "WAERMEERTRAG_RUECKGE_TAG_SUMME_KWH" , property_wh: "WAERMEERTRAG_RUECKGE_TAG_WH"  , property_kwh: "WAERMEERTRAG_RUECKGE_TAG_KWH"  }}
   WAERMEERTRAG_2WE_WW_TAG_SUMME_KWH:   !include { file: wp_daily_energy_combined.yaml, vars: { sensor_name: "WAERMEERTRAG_2WE_WW_TAG_SUMME_KWH"  , property_wh: "WAERMEERTRAG_2WE_WW_TAG_WH"   , property_kwh: "WAERMEERTRAG_2WE_WW_TAG_KWH"   }}

--- a/yaml/wp_number.yaml
+++ b/yaml/wp_number.yaml
@@ -19,16 +19,11 @@ number:
           ESP_LOGI("Number", "Setting new value %f for %s", x, std::string(Property::k${property}.name).c_str());
           if(x != NAN) {
             const auto type = Property::k${property}.type;
-            switch(type) {
-              case Type::et_little_endian: {
-                  const auto value{static_cast<std::uint16_t>(x)};
-                  const auto raw_value = static_cast<std::uint16_t>((((value >> 8U) & 0xFF) | ((value & 0xff) << 8U)));
-                  sendData(${target}, Property::k${property}, raw_value);
-                  break;
-                }
-              default:
-                sendData(${target}, Property::k${property}, static_cast<std::uint16_t>(round(x / ${step})));
-                break;
+            const auto value = GetRawByType(SimpleVariant(x),type);
+            if(value.has_value()) {
+                sendData(${target}, Property::k${property}, *value);
+            } else {
+              ESP_LOGE("Number", "Setting new value failed!");
             }
           }
 


### PR DESCRIPTION
Previously it was wrongly assumed that "step" reflects the type used
by the heatpump. This is not always the case.

Fixes: #196