### PR TITLE
Change ConditionalRequest to ConditionalTask to be able to use with c…

### DIFF
--- a/src/custom_climate.h
+++ b/src/custom_climate.h
@@ -89,8 +89,8 @@ class CustomClimate : public Component, public Climate {
 
             // Send target temp to climate
             for (const auto& targetTemperatureProperty : targetTemperatureProperties_) {
-                sendData(targetTemperatureProperty.first, targetTemperatureProperty.second,
-                         static_cast<std::uint16_t>(temp * 10.0f));
+                queueTransmission(targetTemperatureProperty.first, targetTemperatureProperty.second,
+                                  static_cast<std::uint16_t>(temp * 10.0f));
             }
         }
         // Publish updated state

--- a/src/util.h
+++ b/src/util.h
@@ -18,11 +18,11 @@ void syncTime() {
     }
     ESP_LOGI("TIMESYNC", "Synchronizing heat pump time to %d.%d.%d %d:%d", time.day_of_month, time.month, time.year,
              time.hour, time.minute);
-    sendData(Kessel, Property::kJAHR, toggleEndianness(time.year - 2000U));
-    sendData(Kessel, Property::kMONAT, toggleEndianness(time.month));
-    sendData(Kessel, Property::kTAG, toggleEndianness(time.day_of_month));
-    sendData(Kessel, Property::kSTUNDE, toggleEndianness(time.hour));
-    sendData(Kessel, Property::kMINUTE, toggleEndianness(time.minute));
+    queueTransmission(Kessel, Property::kJAHR, toggleEndianness(time.year - 2000U));
+    queueTransmission(Kessel, Property::kMONAT, toggleEndianness(time.month));
+    queueTransmission(Kessel, Property::kTAG, toggleEndianness(time.day_of_month));
+    queueTransmission(Kessel, Property::kSTUNDE, toggleEndianness(time.hour));
+    queueTransmission(Kessel, Property::kMINUTE, toggleEndianness(time.minute));
 }
 
 #endif

--- a/yaml/common.yaml
+++ b/yaml/common.yaml
@@ -83,14 +83,18 @@ interval:
     then:
       - lambda: |-
           // Request sensor value one after another.
-          if(!conditionalRequests.empty()) {
+          if(!conditionalTasks.empty()) {
             // find the next request of which the condition evaluates to true
-            auto it = std::find_if(conditionalRequests.begin(),conditionalRequests.end(),[](const auto& element){
+            auto it = std::find_if(conditionalTasks.begin(),conditionalTasks.end(),[](const auto& element){
               return element._condition();
             });
-            if(it != conditionalRequests.end()) {
-                requestData(it->_request.first, it->_request.second);
-                conditionalRequests.erase(it);
+            if(it != conditionalTasks.end()) {
+                if(it->_value) {
+                  sendData(it->_task.first, it->_task.second, it->_value.value());
+                } else {
+                  requestData(it->_task.first, it->_task.second);
+                }
+                conditionalTasks.erase(it);
             }
           }
   - interval: $interval_medium
@@ -100,13 +104,13 @@ interval:
           const auto room_temp = id(gRAUMISTTEMP);
           if(room_temp > 0.0f) {
             ESP_LOGI("SET", "Sending cached room temperature %f to heatpump", room_temp);
-            sendData(HK1, Property::kRAUMISTTEMP, static_cast<std::uint16_t>(room_temp * 10.0f));
+            queueTransmission(HK1, Property::kRAUMISTTEMP, static_cast<std::uint16_t>(room_temp * 10.0f));
           }
           // Send current RAUMFEUCHTE
           const auto humidity = id(gRAUMFEUCHTE);
           if(humidity > 0.0) {
             ESP_LOGI("SET", "Sending cached humidity %f to heatpump", humidity);
-            sendData(HK1, Property::kRAUMFEUCHTE, static_cast<std::uint16_t>(humidity * 10.0f));
+            queueTransmission(HK1, Property::kRAUMFEUCHTE, static_cast<std::uint16_t>(humidity * 10.0f));
           }
 
 #########################################
@@ -174,7 +178,7 @@ api:
             const auto value{static_cast<std::uint16_t>(raw_value)};
             if(const auto member = getCanMemberByName(target); member.has_value()) {
               ESP_LOGI("ACTION", "Sending value %d for property %s (0x%04x) to %s", value, std::string(mappedProperty.name).c_str(), mappedProperty.id, target.c_str());
-              sendData(member.value(), mappedProperty, value);
+              queueTransmission(member.value(), mappedProperty, value);
             } else {
               ESP_LOGI("ACTION","No CanMember with name %s defined!", target.c_str());
             }

--- a/yaml/ttf07.yaml
+++ b/yaml/ttf07.yaml
@@ -58,7 +58,7 @@ select:
             const auto betriebsartId = Mapper::instance().getBetriebsartId(x);
             if(betriebsartId.has_value()) {
               ESP_LOGI("ttf07.yaml:select", "Updating PROGRAMMSCHALTER to %s betriebsartId=0x%0x", x.c_str(), betriebsartId.value());
-              sendData(Kessel, Property::kPROGRAMMSCHALTER, betriebsartId.value());
+              queueTransmission(Kessel, Property::kPROGRAMMSCHALTER, betriebsartId.value());
             }
 
 packages:

--- a/yaml/wp_base.yaml
+++ b/yaml/wp_base.yaml
@@ -108,7 +108,7 @@ select:
         - lambda: |-
             const auto passivkuehlungId = Mapper::instance().getPassivkuehlungId(x);
             if(passivkuehlungId.has_value()) {
-              sendData(Kessel, Property::kPASSIVKUEHLUNG, passivkuehlungId.value());
+              queueTransmission(Kessel, Property::kPASSIVKUEHLUNG, passivkuehlungId.value());
             }
 
   - platform: template
@@ -131,7 +131,7 @@ select:
         - lambda: |-
             const auto betriebsartId = Mapper::instance().getBetriebsartId(x);
             if(betriebsartId.has_value()) {
-              sendData(Kessel, Property::kPROGRAMMSCHALTER, betriebsartId.value());
+              queueTransmission(Kessel, Property::kPROGRAMMSCHALTER, betriebsartId.value());
             }
 
 #########################################
@@ -333,5 +333,5 @@ button:
     name: "Reset Filter"
     on_press:
         lambda: |-
-            sendData(Kessel, Property::kRESET_FILTER, 1U);
+            queueTransmission(Kessel, Property::kRESET_FILTER, 1U);
             scheduleRequest(Kessel, Property::kLAUFZEIT_FILTER_TAGE, std::chrono::seconds(30));

--- a/yaml/wp_number.yaml
+++ b/yaml/wp_number.yaml
@@ -24,7 +24,7 @@ number:
             const auto type = Property::k${property}.type;
             const auto value = GetRawByType(SimpleVariant(x),type);
             if(value.has_value()) {
-                sendData(${target}, Property::k${property}, *value);
+                queueTransmission(${target}, Property::k${property}, *value);
             } else {
               ESP_LOGE("Number", "Setting new value failed!");
             }

--- a/yaml/wp_switch.yaml
+++ b/yaml/wp_switch.yaml
@@ -10,10 +10,10 @@ switch:
     restore_mode: RESTORE_DEFAULT_OFF
     turn_on_action:
       - lambda: |-
-          sendData(${target}, Property::k${property}, static_cast<std::uint16_t>(true));
+          queueTransmission(${target}, Property::k${property}, static_cast<std::uint16_t>(true));
     turn_off_action:
       - lambda: |-
-          sendData(${target}, Property::k${property}, static_cast<std::uint16_t>(false));
+          queueTransmission(${target}, Property::k${property}, static_cast<std::uint16_t>(false));
 
 esphome:
   on_boot:

--- a/yaml/wp_ventilation.yaml
+++ b/yaml/wp_ventilation.yaml
@@ -8,7 +8,7 @@ fan:
       - lambda: |-
           const auto fan_speed = std::min(3, x);
           ESP_LOGI("fan", "Speed set %d", fan_speed);
-          sendData(Kessel, Property::k${property}, fan_speed);
+          queueTransmission(Kessel, Property::k${property}, fan_speed);
           scheduleRequest(Kessel, Property::kZULUFT_SOLL, std::chrono::seconds(10));
           scheduleRequest(Kessel, Property::kZULUFT_IST, std::chrono::seconds(10));
           scheduleRequest(Kessel, Property::kABLUFT_SOLL, std::chrono::seconds(10));
@@ -16,7 +16,7 @@ fan:
     on_turn_off:
       - lambda: |-
           ESP_LOGI("fan", "Fan turned off!");
-          sendData(Kessel, Property::k${property}, 0U);
+          queueTransmission(Kessel, Property::k${property}, 0U);
           scheduleRequest(Kessel, Property::kZULUFT_SOLL, std::chrono::seconds(10));
           scheduleRequest(Kessel, Property::kZULUFT_IST, std::chrono::seconds(10));
           scheduleRequest(Kessel, Property::kABLUFT_SOLL, std::chrono::seconds(10));
@@ -24,7 +24,7 @@ fan:
     on_turn_on:
       - lambda: |-
           ESP_LOGI("fan", "Fan turned on!");
-          sendData(Kessel, Property::k${property}, id(${property}).speed);
+          queueTransmission(Kessel, Property::k${property}, id(${property}).speed);
           scheduleRequest(Kessel, Property::kZULUFT_SOLL, std::chrono::seconds(10));
           scheduleRequest(Kessel, Property::kZULUFT_IST, std::chrono::seconds(10));
           scheduleRequest(Kessel, Property::kABLUFT_SOLL, std::chrono::seconds(10));

--- a/yaml/wpl13.yaml
+++ b/yaml/wpl13.yaml
@@ -128,14 +128,18 @@ interval:
     then:
       - lambda: |-
           // Request sensor value one after another.
-          if(!conditionalRequests.empty()) {
+          if(!conditionalTasks.empty()) {
             // find the next request of which the condition evaluates to true
-            auto it = std::find_if(conditionalRequests.begin(),conditionalRequests.end(),[](const auto& element){
+            auto it = std::find_if(conditionalTasks.begin(),conditionalTasks.end(),[](const auto& element){
               return element._condition();
             });
-            if(it != conditionalRequests.end()) {
-                requestData(it->_request.first, it->_request.second);
-                conditionalRequests.erase(it);
+            if(it != conditionalTasks.end()) {
+                if(it->_value) {
+                  sendData(it->_task.first, it->_task.second, it->_value.value());
+                } else {
+                  requestData(it->_task.first, it->_task.second);
+                }
+                conditionalTasks.erase(it);
             }
           }
 
@@ -163,7 +167,7 @@ select:
         - lambda: |-
             const auto betriebsartId = Mapper::instance().getBetriebsartId(x);
             if(betriebsartId.has_value()) {
-              sendData(WPM2, Property::kPROGRAMMSCHALTER, (betriebsartId.value() >> 8U) & 0xFF);
+              queueTransmission(WPM2, Property::kPROGRAMMSCHALTER, (betriebsartId.value() >> 8U) & 0xFF);
             }
 
 #########################################


### PR DESCRIPTION
…anSend

It makes sense that ALL CAN communication goes through the rate limiter, not only the requests. Generalizing ConditionalRequest into ConditionalTasks allows us to queue tasks and execute them conditionally.

This might fix #231