### PR TITLE
Drop SNTP time and use recommended Home Assistant time platform

### DIFF
--- a/esp32-poe-technik.yaml
+++ b/esp32-poe-technik.yaml
@@ -28,10 +28,6 @@ ota:
   platform: esphome
   password: !secret ota_password
 
-time:
-  - platform: homeassistant
-    id: homeassistant_time
-
 substitutions:
   interval_very_fast: 15s
   interval_fast: 30s
@@ -42,6 +38,7 @@ substitutions:
 
   entity_room_temperature: "sensor.durchschnittstemperatur_haus_ohne_keller"
   entity_humidity: "sensor.durchschnitt_luftfeuchtigkeit_haus"
+  timezone: "Europe/Berlin"
 
 #########################################
 #                                       #

--- a/src/util.h
+++ b/src/util.h
@@ -8,21 +8,21 @@
 #include "type.h"
 
 /**
- * @brief Synchronizes the time of the heat pump to the one received via sntp.
+ * @brief Synchronizes the time of the heat pump to the one received via Home Assistant time platform.
  */
 void syncTime() {
-    const auto time = id(sntp_time).now();
+    const auto time = id(homeassistant_time).now();
     if (!time.is_valid()) {
-        ESP_LOGE("TIMESYNC", "Cannot sync time. SNTP time is invalid.");
+        ESP_LOGE("TIMESYNC", "Cannot sync time. Home Assistant time is invalid.");
         return;
     }
     ESP_LOGI("TIMESYNC", "Synchronizing heat pump time to %d.%d.%d %d:%d", time.day_of_month, time.month, time.year,
              time.hour, time.minute);
-    queueTransmission(Kessel, Property::kJAHR, toggleEndianness(time.year - 2000U));
-    queueTransmission(Kessel, Property::kMONAT, toggleEndianness(time.month));
-    queueTransmission(Kessel, Property::kTAG, toggleEndianness(time.day_of_month));
-    queueTransmission(Kessel, Property::kSTUNDE, toggleEndianness(time.hour));
-    queueTransmission(Kessel, Property::kMINUTE, toggleEndianness(time.minute));
+    sendData(Kessel, Property::kJAHR, toggleEndianness(time.year - 2000U));
+    sendData(Kessel, Property::kMONAT, toggleEndianness(time.month));
+    sendData(Kessel, Property::kTAG, toggleEndianness(time.day_of_month));
+    sendData(Kessel, Property::kSTUNDE, toggleEndianness(time.hour));
+    sendData(Kessel, Property::kMINUTE, toggleEndianness(time.minute));
 }
 
 #endif

--- a/yaml/common.yaml
+++ b/yaml/common.yaml
@@ -50,12 +50,14 @@ globals:
 #                                       #
 #########################################
 time:
-  - platform: sntp
-    id: sntp_time
+  - platform: homeassistant
+    id: homeassistant_time
+    timezone: $timezone
     on_time:
       - seconds: 0
-        minutes: 0
+        minutes: 5
         hours: 3 # sync at 3 am should be ok even with switch from/to daylight saving time
+        days_of_week: SUN
         then:
           - lambda: |-
               syncTime();

--- a/yaml/wp_daily_energy_combined.yaml
+++ b/yaml/wp_daily_energy_combined.yaml
@@ -50,7 +50,7 @@ esphome:
 
 time:
   - platform: sntp
-    id: !extend sntp_time
+    id: !extend homeassistant_time
     on_time:
       # Every hour, every 5 minutes starting at 4th minute.
       - seconds: 0

--- a/yaml/wpl13.yaml
+++ b/yaml/wpl13.yaml
@@ -95,12 +95,14 @@ globals:
 #                                       #
 #########################################
 time:
-  - platform: sntp
-    id: sntp_time
+  - platform: homeassistant
+    id: homeassistant_time
+    timezone: $timezone
     on_time:
       - seconds: 0
-        minutes: 0
+        minutes: 5
         hours: 3 # sync at 3 am should be ok even with switch from/to daylight saving time
+        days_of_week: SUN
         then:
           - lambda: |-
               syncTime();


### PR DESCRIPTION
Fixes: https://github.com/kr0ner/OneESP32ToRuleThemAll/issues/245

This might have been the root cause. Bug not visible to me, because I build on the same server as I run HA on.
> timezone (Optional, string): Manually tell ESPHome what time zone to use with this format (warning: the format is quite complicated, see examples) or the simpler TZ database name in the form <Region>/<City>. ESPHome tries to automatically infer the time zone string based on the time zone of the computer that is running ESPHome, but this might not always be accurate.

https://esphome.io/components/time/homeassistant/ is the preferred time provider anyways

> The preferred way to get time in ESPHome is using Home Assistant. With the homeassistant time platform, the [native API](https://esphome.io/components/api/) connection to Home Assistant will be used to periodically synchronize the current time.

AI:
> Recommendation: Move your daily sync/broadcast to 03:05. By 3:05 AM, the time shift (forward or backward) is settled, and there is no ambiguity about which "3 AM" you are in. 