### PR TITLE
Decouple request & transmission queue

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -18,11 +18,11 @@ void syncTime() {
     }
     ESP_LOGI("TIMESYNC", "Synchronizing heat pump time to %d.%d.%d %d:%d", time.day_of_month, time.month, time.year,
              time.hour, time.minute);
-    sendData(Kessel, Property::kJAHR, toggleEndianness(time.year - 2000U));
-    sendData(Kessel, Property::kMONAT, toggleEndianness(time.month));
-    sendData(Kessel, Property::kTAG, toggleEndianness(time.day_of_month));
-    sendData(Kessel, Property::kSTUNDE, toggleEndianness(time.hour));
-    sendData(Kessel, Property::kMINUTE, toggleEndianness(time.minute));
+    queueTransmission(Kessel, Property::kJAHR, toggleEndianness(time.year - 2000U));
+    queueTransmission(Kessel, Property::kMONAT, toggleEndianness(time.month));
+    queueTransmission(Kessel, Property::kTAG, toggleEndianness(time.day_of_month));
+    queueTransmission(Kessel, Property::kSTUNDE, toggleEndianness(time.hour));
+    queueTransmission(Kessel, Property::kMINUTE, toggleEndianness(time.minute));
 }
 
 #endif

--- a/yaml/common.yaml
+++ b/yaml/common.yaml
@@ -79,18 +79,28 @@ interval:
     then:
       - lambda: |-
           // Request sensor value one after another.
-          if(!conditionalTasks.empty()) {
+          if(!getConditionalRequests().empty()) {
             // find the next request of which the condition evaluates to true
-            auto it = std::find_if(conditionalTasks.begin(),conditionalTasks.end(),[](const auto& element){
+            auto it = std::find_if(getConditionalRequests().begin(),getConditionalRequests().end(),[](const auto& element){
               return element._condition();
             });
-            if(it != conditionalTasks.end()) {
-                if(it->_value) {
-                  sendData(it->_task.first, it->_task.second, it->_value.value());
-                } else {
-                  requestData(it->_task.first, it->_task.second);
-                }
-                conditionalTasks.erase(it);
+            if(it != getConditionalRequests().end()) {
+              requestData(it->_task.first, it->_task.second);
+              getConditionalRequests().erase(it);
+            }
+          }
+  - interval: 50ms
+    then:
+      - lambda: |-
+          // Request sensor value one after another.
+          if(!getConditionalTransmissions().empty()) {
+            // find the next request of which the condition evaluates to true
+            auto it = std::find_if(getConditionalTransmissions().begin(),getConditionalTransmissions().end(),[](const auto& element){
+              return element._condition();
+            });
+            if(it != getConditionalTransmissions().end()) {
+              sendData(it->_task.first, it->_task.second, it->_value);
+              getConditionalTransmissions().erase(it);
             }
           }
 

--- a/yaml/wpl13.yaml
+++ b/yaml/wpl13.yaml
@@ -130,18 +130,28 @@ interval:
     then:
       - lambda: |-
           // Request sensor value one after another.
-          if(!conditionalTasks.empty()) {
+          if(!getConditionalRequests().empty()) {
             // find the next request of which the condition evaluates to true
-            auto it = std::find_if(conditionalTasks.begin(),conditionalTasks.end(),[](const auto& element){
+            auto it = std::find_if(getConditionalRequests().begin(),getConditionalRequests().end(),[](const auto& element){
               return element._condition();
             });
-            if(it != conditionalTasks.end()) {
-                if(it->_value) {
-                  sendData(it->_task.first, it->_task.second, it->_value.value());
-                } else {
-                  requestData(it->_task.first, it->_task.second);
-                }
-                conditionalTasks.erase(it);
+            if(it != getConditionalRequests().end()) {
+              requestData(it->_task.first, it->_task.second);
+              getConditionalRequests().erase(it);
+            }
+          }
+  - interval: 50ms
+    then:
+      - lambda: |-
+          // Request sensor value one after another.
+          if(!getConditionalTransmissions().empty()) {
+            // find the next request of which the condition evaluates to true
+            auto it = std::find_if(getConditionalTransmissions().begin(),getConditionalTransmissions().end(),[](const auto& element){
+              return element._condition();
+            });
+            if(it != getConditionalTransmissions().end()) {
+              sendData(it->_task.first, it->_task.second, it->_value);
+              getConditionalTransmissions().erase(it);
             }
           }
 


### PR DESCRIPTION
This change allows us to set different timing requirements for fire-and-forget (transmission) and request-response use cases.  

Fixes: https://github.com/kr0ner/OneESP32ToRuleThemAll/issues/245