### PR TITLE
Fix broken energymeter for 2026.3.x

### DIFF
--- a/components/sml_reader/__init__.py
+++ b/components/sml_reader/__init__.py
@@ -1,0 +1,58 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import uart, esp32, sensor
+from esphome.const import CONF_ID, CONF_UART_ID
+
+DEPENDENCIES = ['uart', 'esp32']
+AUTO_LOAD = ['uart']
+
+SMLReader = cg.global_ns.class_('SMLReader', cg.Component, uart.UARTDevice)
+
+CONF_MQTT_SERVER = 'mqtt_server'
+CONF_MQTT_USER = 'mqtt_user'
+CONF_MQTT_PASSWORD = 'mqtt_password'
+
+CONF_SENSORS = [
+    'instantaneous_power', 'instantaneous_power_l1', 'instantaneous_power_l2', 'instantaneous_power_l3',
+    'instantaneous_voltage_l1', 'instantaneous_voltage_l2', 'instantaneous_voltage_l3',
+    'instantaneous_current_l1', 'instantaneous_current_l2', 'instantaneous_current_l3',
+    'frequency', 'total_incoming', 'total_outgoing'
+]
+
+schema = cv.Schema({
+    cv.GenerateID(): cv.declare_id(SMLReader),
+    cv.Required(CONF_UART_ID): cv.use_id(uart.UARTComponent),
+    cv.Required(CONF_MQTT_SERVER): cv.string,
+    cv.Required(CONF_MQTT_USER): cv.string,
+    cv.Required(CONF_MQTT_PASSWORD): cv.string,
+}).extend(cv.COMPONENT_SCHEMA).extend(uart.UART_DEVICE_SCHEMA)
+
+for s_conf in CONF_SENSORS:
+    schema = schema.extend({cv.Optional(s_conf): cv.use_id(sensor.Sensor)})
+
+CONFIG_SCHEMA = schema
+
+async def to_code(config):
+    esp32.add_idf_component(
+        name="libsml",
+        repo="https://github.com/kr0ner/libsml",
+        ref="master"
+    )
+
+    uart_comp = await cg.get_variable(config[CONF_UART_ID])
+
+    var = cg.new_Pvariable(
+        config[CONF_ID],
+        uart_comp,
+        config[CONF_MQTT_SERVER],
+        config[CONF_MQTT_USER],
+        config[CONF_MQTT_PASSWORD]
+    )
+
+    for s_conf in CONF_SENSORS:
+        if s_conf in config:
+            sens = await cg.get_variable(config[s_conf])
+            cg.add(getattr(var, f"set_{s_conf}")(sens))
+
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)

--- a/components/sml_reader/sml_reader.h
+++ b/components/sml_reader/sml_reader.h
@@ -11,6 +11,8 @@
 #include <vector>
 #include "esphome.h"
 #include "esphome/components/network/util.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/uart/uart.h"
 #include "mqtt_client.h"
 
 namespace {
@@ -68,11 +70,26 @@ struct Readings {
     float frequency{0.0f};
 };
 
-class SMLReader : public Component, public UARTDevice {
+class SMLReader : public esphome::Component, public esphome::uart::UARTDevice {
     std::vector<std::uint8_t> _buffer;
     State _current_state{State::kWaitingForStartSequence};
     sml_file* _file;
     std::optional<Readings> _readings;
+
+    // ESPHome sensors
+    esphome::sensor::Sensor* instantaneous_power_{nullptr};
+    esphome::sensor::Sensor* instantaneous_power_l1_{nullptr};
+    esphome::sensor::Sensor* instantaneous_power_l2_{nullptr};
+    esphome::sensor::Sensor* instantaneous_power_l3_{nullptr};
+    esphome::sensor::Sensor* instantaneous_voltage_l1_{nullptr};
+    esphome::sensor::Sensor* instantaneous_voltage_l2_{nullptr};
+    esphome::sensor::Sensor* instantaneous_voltage_l3_{nullptr};
+    esphome::sensor::Sensor* instantaneous_current_l1_{nullptr};
+    esphome::sensor::Sensor* instantaneous_current_l2_{nullptr};
+    esphome::sensor::Sensor* instantaneous_current_l3_{nullptr};
+    esphome::sensor::Sensor* frequency_{nullptr};
+    esphome::sensor::Sensor* total_incoming_{nullptr};
+    esphome::sensor::Sensor* total_outgoing_{nullptr};
 
     // Native MQTT Client & State
     esp_mqtt_client_handle_t _private_client{nullptr};
@@ -105,13 +122,13 @@ class SMLReader : public Component, public UARTDevice {
 
     template <typename T, typename F>
     void waitForSequence(const T& sequence, F func) {
-        while (available()) {
+        while (this->available()) {
             if (_buffer.size() == _buffer.capacity()) {
                 // start over
                 ESP_LOGV("SMLReader", "clearing buffer");
                 _buffer.clear();
             }
-            _buffer.push_back(read());
+            _buffer.push_back(this->read());
 
             // wait until there are at least as many bytes as the sequence to start comparison
             if (_buffer.size() >= sequence.size()) {
@@ -241,19 +258,45 @@ class SMLReader : public Component, public UARTDevice {
     }
 
     void publishHA(const Readings& readings) const {
-        id(Instantaneous_Power).publish_state(readings.power);
-        id(Instantaneous_Power_L1).publish_state(readings.power_l1);
-        id(Instantaneous_Power_L2).publish_state(readings.power_l2);
-        id(Instantaneous_Power_L3).publish_state(readings.power_l3);
-        id(Instantaneous_Voltage_L1).publish_state(readings.voltage_l1);
-        id(Instantaneous_Voltage_L2).publish_state(readings.voltage_l2);
-        id(Instantaneous_Voltage_L3).publish_state(readings.voltage_l3);
-        id(Instantaneous_Current_L1).publish_state(readings.current_l1);
-        id(Instantaneous_Current_L2).publish_state(readings.current_l2);
-        id(Instantaneous_Current_L3).publish_state(readings.current_l3);
-        id(Frequency).publish_state(readings.frequency);
-        id(Total_Incoming).publish_state(readings.total_incoming);
-        id(Total_Outgoing).publish_state(readings.total_outgoing);
+        if (this->instantaneous_power_ != nullptr) {
+            this->instantaneous_power_->publish_state(readings.power);
+        }
+        if (this->instantaneous_power_l1_ != nullptr) {
+            this->instantaneous_power_l1_->publish_state(readings.power_l1);
+        }
+        if (this->instantaneous_power_l2_ != nullptr) {
+            this->instantaneous_power_l2_->publish_state(readings.power_l2);
+        }
+        if (this->instantaneous_power_l3_ != nullptr) {
+            this->instantaneous_power_l3_->publish_state(readings.power_l3);
+        }
+        if (this->instantaneous_voltage_l1_ != nullptr) {
+            this->instantaneous_voltage_l1_->publish_state(readings.voltage_l1);
+        }
+        if (this->instantaneous_voltage_l2_ != nullptr) {
+            this->instantaneous_voltage_l2_->publish_state(readings.voltage_l2);
+        }
+        if (this->instantaneous_voltage_l3_ != nullptr) {
+            this->instantaneous_voltage_l3_->publish_state(readings.voltage_l3);
+        }
+        if (this->instantaneous_current_l1_ != nullptr) {
+            this->instantaneous_current_l1_->publish_state(readings.current_l1);
+        }
+        if (this->instantaneous_current_l2_ != nullptr) {
+            this->instantaneous_current_l2_->publish_state(readings.current_l2);
+        }
+        if (this->instantaneous_current_l3_ != nullptr) {
+            this->instantaneous_current_l3_->publish_state(readings.current_l3);
+        }
+        if (this->frequency_ != nullptr) {
+            this->frequency_->publish_state(readings.frequency);
+        }
+        if (this->total_incoming_ != nullptr) {
+            this->total_incoming_->publish_state(readings.total_incoming);
+        }
+        if (this->total_outgoing_ != nullptr) {
+            this->total_outgoing_->publish_state(readings.total_outgoing);
+        }
     }
 
     void initMQTT() {
@@ -282,8 +325,8 @@ class SMLReader : public Component, public UARTDevice {
     }
 
    public:
-    SMLReader(UARTComponent* parent, std::string server, std::string user, std::string password)
-        : UARTDevice(parent), _mqtt_user(std::move(user)), _mqtt_pass(std::move(password)) {
+    SMLReader(esphome::uart::UARTComponent* parent, std::string server, std::string user, std::string password)
+        : esphome::uart::UARTDevice(parent), _mqtt_user(std::move(user)), _mqtt_pass(std::move(password)) {
         _mqtt_uri = "mqtt://" + server + ":1883";
     }
 
@@ -323,4 +366,18 @@ class SMLReader : public Component, public UARTDevice {
                 break;
         }
     }
+
+    void set_instantaneous_power(esphome::sensor::Sensor* s) { instantaneous_power_ = s; }
+    void set_instantaneous_power_l1(esphome::sensor::Sensor* s) { instantaneous_power_l1_ = s; }
+    void set_instantaneous_power_l2(esphome::sensor::Sensor* s) { instantaneous_power_l2_ = s; }
+    void set_instantaneous_power_l3(esphome::sensor::Sensor* s) { instantaneous_power_l3_ = s; }
+    void set_instantaneous_voltage_l1(esphome::sensor::Sensor* s) { instantaneous_voltage_l1_ = s; }
+    void set_instantaneous_voltage_l2(esphome::sensor::Sensor* s) { instantaneous_voltage_l2_ = s; }
+    void set_instantaneous_voltage_l3(esphome::sensor::Sensor* s) { instantaneous_voltage_l3_ = s; }
+    void set_instantaneous_current_l1(esphome::sensor::Sensor* s) { instantaneous_current_l1_ = s; }
+    void set_instantaneous_current_l2(esphome::sensor::Sensor* s) { instantaneous_current_l2_ = s; }
+    void set_instantaneous_current_l3(esphome::sensor::Sensor* s) { instantaneous_current_l3_ = s; }
+    void set_frequency(esphome::sensor::Sensor* s) { frequency_ = s; }
+    void set_total_incoming(esphome::sensor::Sensor* s) { total_incoming_ = s; }
+    void set_total_outgoing(esphome::sensor::Sensor* s) { total_outgoing_ = s; }
 };

--- a/yaml/features/energymeter.yaml
+++ b/yaml/features/energymeter.yaml
@@ -1,17 +1,6 @@
 defaults:
   rx_pin: "GPIO2"
 
-esphome:
-  includes:
-    - OneESP32ToRuleThemAll/src/sml_reader.h
-
-esp32:
-  framework:
-    components:
-      - name: libsml
-        source: https://github.com/kr0ner/libsml
-        ref: master
-
 #########################################
 #                                       #
 #   UART configuration                  #
@@ -35,12 +24,25 @@ substitutions:
 external_components:
   - source: OneESP32ToRuleThemAll/components
 
-custom_component:
-  - lambda: |-
-      auto sml_reader = new SMLReader(id(smartmeter_uart),"${mqtt_server}","${mqtt_user}","${mqtt_password}");
-      return {sml_reader};
-    components:
-      - id: sml_reader_component
+sml_reader:
+  id: sml_reader_component
+  uart_id: smartmeter_uart
+  mqtt_server: "${mqtt_server}"
+  mqtt_user: "${mqtt_user}"
+  mqtt_password: "${mqtt_password}"
+  total_incoming: Total_Incoming
+  total_outgoing: Total_Outgoing
+  instantaneous_power: Instantaneous_Power
+  frequency: Frequency
+  instantaneous_power_l1: Instantaneous_Power_L1
+  instantaneous_power_l2: Instantaneous_Power_L2
+  instantaneous_power_l3: Instantaneous_Power_L3
+  instantaneous_voltage_l1: Instantaneous_Voltage_L1
+  instantaneous_voltage_l2: Instantaneous_Voltage_L2
+  instantaneous_voltage_l3: Instantaneous_Voltage_L3
+  instantaneous_current_l1: Instantaneous_Current_L1
+  instantaneous_current_l2: Instantaneous_Current_L2
+  instantaneous_current_l3: Instantaneous_Current_L3
 
 #########################################
 #                                       #


### PR DESCRIPTION
Apparently the UART polling was removed and only works, if you create a "real" external component.