### PR TITLE
Rename fallback hotspot SSID to 'ESP32-Standalone Fallback AP'

### DIFF
--- a/esp32-standalone.yaml
+++ b/esp32-standalone.yaml
@@ -92,7 +92,7 @@ wifi:
 
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
-    ssid: "ESP32-Standalone Fallback Hotspot"
+    ssid: "ESP32-Standalone Fallback AP"
     password: !secret fallback_password
 
 #########################################


### PR DESCRIPTION
The fallback hotspot SSID exceeded the 32-character limit defined by the IEEE 802.11 standard, causing ESPHome compilation to fail