### PR TITLE
Avoid 'always true' std::function

### DIFF
--- a/components/wp_core/communication.h
+++ b/components/wp_core/communication.h
@@ -54,9 +54,7 @@ struct ConditionalTransmission {
 
     Task _task;
     std::uint16_t _value;
-    std::function<bool()> _condition = []() {
-        return true;
-    };
+    std::function<bool()> _condition = nullptr;
 };
 
 /**

--- a/yaml/core.yaml
+++ b/yaml/core.yaml
@@ -80,7 +80,7 @@ interval:
           if(!getConditionalRequests().empty()) {
             // find the next request of which the condition evaluates to true
             auto it = std::find_if(getConditionalRequests().begin(),getConditionalRequests().end(),[](const auto& element){
-              return element._condition();
+              return !element._condition || element._condition();
             });
             if(it != getConditionalRequests().end()) {
               requestData(wp_can, it->_task.first, it->_task.second);
@@ -94,7 +94,7 @@ interval:
           if(!getConditionalTransmissions().empty()) {
             // find the next request of which the condition evaluates to true
             auto it = std::find_if(getConditionalTransmissions().begin(),getConditionalTransmissions().end(),[](const auto& element){
-              return element._condition();
+              return !element._condition || element._condition();
             });
             if(it != getConditionalTransmissions().end()) {
               sendData(wp_can, it->_task.first, it->_task.second, it->_value);


### PR DESCRIPTION
'Empty' std::function takes way more memory than a nullptr. Most of the requests are not conditional and we can save a lot of heap