### PR TITLE
Decode Elster sentinel values as unavailable instead of garbage numbers

### DIFF
--- a/components/wp_core/type.cpp
+++ b/components/wp_core/type.cpp
@@ -18,6 +18,7 @@
 #include "type.h"
 
 #include <algorithm>
+#include <cmath>
 #include <string>
 
 #include "mapper.h"
@@ -28,10 +29,20 @@ SimpleVariant GetValueByType(const std::uint16_t value, const Type type) {
         case Type::et_byte:
             return (static_cast<float>(value & 0xFF));
         case Type::et_dec_val:
+            // 0x8000 = "not available", 0x9000 = "AUS" (e.g. MINTEMP shows "AUS" on the panel)
+            if (value == 0x8000U || value == 0x9000U) {
+                return NAN;
+            }
             return (static_cast<std::int16_t>(value) / 10.0f);
         case Type::et_cent_val:
+            if (value == 0x8000U) {  // "not available"
+                return NAN;
+            }
             return (static_cast<std::int16_t>(value) / 100.0f);
         case Type::et_mil_val:
+            if (value == 0x8000U) {  // "not available"
+                return NAN;
+            }
             return (static_cast<std::int16_t>(value) / 1000.0f);
         case Type::et_little_endian:
             return static_cast<float>((((value >> 8U) & 0xFF) | ((value & 0xff) << 8U)));
@@ -96,6 +107,9 @@ SimpleVariant GetValueByType(const std::uint16_t value, const Type type) {
         case Type::et_double_val:
             [[fallthrough]];
         case Type::et_triple_val:
+            if (value == 0x8000U) {  // "not available"
+                return NAN;
+            }
             return static_cast<std::int16_t>(value) * 1.0f;
         case Type::et_default:
             [[fallthrough]];


### PR DESCRIPTION
Related: #363 (finding 2)

**Symptom:** scaled numeric properties render impossible values when the
controller has no data:
- `MINTEMP` (HK2) showed **-2867.2 °C** while the panel shows **AUS**
  (raw `0x9000` through the int16 cast)
- on a pump without DHW, `WAERMEERTRAG_WW_SUMME_MWH` showed **32.768 MWh**
  and `EL_ENERGIEAUFNAHME_WW_SUMME_KWH` **32,768,000 kWh** (raw `0x8000`)

**Fix:** in `GetValueByType`, return `NAN` for `0x8000` ("not available") on
et_dec_val/et_cent_val/et_mil_val/et_double_val/et_triple_val, and for
`0x9000` ("AUS") on et_dec_val. ESPHome then reports the entity as
unavailable in HA instead of publishing garbage.

Deliberately not touched: `et_default`/bitfield types (0x8000 could be a
legitimate raw word there) and the write path (`GetRawByType`).

**Tested on:** WPE-I 08 HK 230 Premium via ESP32-C6, ESPHome 2026.6.5 —
MINTEMP now unavailable, matching the panel's AUS.
